### PR TITLE
Implement KeyedDistribution and KeyedSampleable

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,10 +1,10 @@
 name: CI
-# Run on master, tags, or any pull request
+# Run on main, tags, or any pull request
 on:
   schedule:
     - cron: '0 2 * * *'  # Daily at 2 AM UTC (8 PM CST)
   push:
-    branches: [master]
+    branches: [main]
     tags: ["*"]
   pull_request:
 jobs:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,8 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1'
-          - '1.0'
+          - '1.5'  # Invenia Prod version
+          - '1'    # Latest Release
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -3,11 +3,22 @@ uuid = "2576fb08-064d-4cab-b15d-8dda7fcb9a6d"
 authors = ["Invenia Technical Computing Corporation"]
 version = "0.1.0"
 
+[deps]
+AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
+AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
 [compat]
+AutoHashEquals = "0.2"
+AxisKeys = "0.1"
+Distributions = "0.24"
 julia = "1"
 
 [extras]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["LinearAlgebra", "Statistics", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 AutoHashEquals = "0.2"
 AxisKeys = "0.1"
 Distributions = "0.24"
-julia = "1.3"
+julia = "1.5"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -13,12 +13,14 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 AutoHashEquals = "0.2"
 AxisKeys = "0.1"
 Distributions = "0.24"
+StableRNGs = "1"
 julia = "1.5"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["LinearAlgebra", "Statistics", "Test"]
+test = ["LinearAlgebra", "StableRNGs", "Statistics", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 AutoHashEquals = "0.2"
 AxisKeys = "0.1"
 Distributions = "0.24"
-julia = "1"
+julia = "1.3"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -7,12 +7,14 @@ version = "0.1.0"
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
 AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 AutoHashEquals = "0.2"
 AxisKeys = "0.1"
 Distributions = "0.24"
+IterTools = "1.3"
 StableRNGs = "1"
 julia = "1.5"
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://invenia.github.io/KeyedDistributions.jl/stable)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://invenia.github.io/KeyedDistributions.jl/dev)
 [![Build Status](https://github.com/invenia/KeyedDistributions.jl/workflows/CI/badge.svg)](https://github.com/invenia/KeyedDistributions.jl/actions)
-[![Coverage](https://codecov.io/gh/invenia/KeyedDistributions.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/invenia/KeyedDistributions.jl)
+[![Coverage](https://codecov.io/gh/invenia/KeyedDistributions.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/invenia/KeyedDistributions.jl)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -22,4 +22,6 @@ makedocs(;
 
 deploydocs(;
     repo="github.com/invenia/KeyedDistributions.jl",
+    devbranch = "main",
+    push_preview = true,
 )

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -2,7 +2,6 @@ module KeyedDistributions
 
 using AutoHashEquals
 using AxisKeys
-using AxisKeys: keyless
 using Distributions
 using Random: AbstractRNG
 
@@ -59,10 +58,6 @@ distribution(d::KeyedDistOrSampleable) = d.d
 
 # AxisKeys functionality
 
-Base.parent(d::KeyedDistOrSampleable) = d.d
-
-AxisKeys.keyless(d::KeyedDistOrSampleable) = parent(d)
-
 """
     axiskeys(s::Sampleable)
 
@@ -81,37 +76,37 @@ function Distributions._rand!(
     d::KeyedDistOrSampleable,
     x::AbstractVector{T}
 ) where T<:Real
-    sample = Distributions._rand!(rng, parent(d), x)
+    sample = Distributions._rand!(rng, distribution(d), x)
     return KeyedArray(sample, axiskeys(d))
 end
 
-Base.length(d::KeyedDistOrSampleable) = length(keyless(d))
+Base.length(d::KeyedDistOrSampleable) = length(distribution(d))
 
-Distributions.sampler(d::KeyedDistribution) = sampler(keyless(d))
+Distributions.sampler(d::KeyedDistribution) = sampler(distribution(d))
 
-Base.eltype(d::KeyedDistribution) = eltype(keyless(d))
+Base.eltype(d::KeyedDistribution) = eltype(distribution(d))
 
 Distributions._logpdf(d::KeyedDistribution, x::AbstractArray) =
-    Distributions._logpdf(parent(d), x)
+    Distributions._logpdf(distribution(d), x)
 
 # Also need to overload `rand` methods to return a KeyedArray
 
 Base.rand(rng::AbstractRNG, d::KeyedDistOrSampleable) =
-    KeyedArray(rand(rng, parent(d)), axiskeys(d))
+    KeyedArray(rand(rng, distribution(d)), axiskeys(d))
 
 Base.rand(rng::AbstractRNG, d::KeyedDistOrSampleable, n::Int) =
-    KeyedArray(rand(rng, parent(d), n), (first(axiskeys(d)), Base.OneTo(n)))
+    KeyedArray(rand(rng, distribution(d), n), (first(axiskeys(d)), Base.OneTo(n)))
 
 # Statistics functions for Distribution
 
-Distributions.mean(d::KeyedDistribution) = KeyedArray(mean(keyless(d)), axiskeys(d))
+Distributions.mean(d::KeyedDistribution) = KeyedArray(mean(distribution(d)), axiskeys(d))
 
-Distributions.var(d::KeyedDistribution) = KeyedArray(var(keyless(d)), axiskeys(d))
+Distributions.var(d::KeyedDistribution) = KeyedArray(var(distribution(d)), axiskeys(d))
 
 Distributions.cov(d::KeyedDistribution) =
-    KeyedArray(cov(keyless(d)), (first(axiskeys(d)), first(axiskeys(d))))
+    KeyedArray(cov(distribution(d)), (first(axiskeys(d)), first(axiskeys(d))))
 
-Distributions.entropy(d::KeyedDistribution) = entropy(keyless(d))
-Distributions.entropy(d::KeyedDistribution, b::Real) = entropy(keyless(d), b)
+Distributions.entropy(d::KeyedDistribution) = entropy(distribution(d))
+Distributions.entropy(d::KeyedDistribution, b::Real) = entropy(distribution(d), b)
 
 end

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -57,8 +57,11 @@ Constructs a [`KeyedDistribution`](@ref) using the keys of the first field store
 """
 function KeyedDistribution(d::Distribution)
     first_field = getfield(d, 1)
-    return KeyedDistribution(d, axiskeys(first_field))
+    return KeyedDistribution(d, _keys(first_field))
 end
+
+_keys(x::KeyedArray) = axiskeys(x)
+_keys(x) = map(Base.OneTo, size(x))
 
 const KeyedDistOrSampleable = Union{KeyedDistribution, KeyedSampleable}
 

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -13,12 +13,12 @@ export axiskeys, distribution
 for T in (:Distribution, :Sampleable)
     KeyedT = Symbol(:Keyed, T)
     @eval begin
-        @auto_hash_equals struct $KeyedT{F, S, D<:$T{F, S}} <: $T{F, S}
+        @auto_hash_equals struct $KeyedT{F<:VariateForm, S<:ValueSupport, D<:$T{F, S}} <: $T{F, S}
             d::D
             keys::AbstractVector
 
             """
-            $($KeyedT)(d<:$($T), keys::AbstractVector)
+                $($KeyedT)(d<:$($T), keys::AbstractVector)
 
             Stores `keys` for each variate alongside the `$($T)` `d`.
             """

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -13,7 +13,7 @@ for T in (:Distribution, :Sampleable)
     KeyedT = Symbol(:Keyed, T)
     @eval begin
         """
-            $($KeyedT)(d<:$($T), keys::Tuple{AbstractVector})
+            $($KeyedT)(d<:$($T), keys::Tuple{Vararg{AbstractVector}})
 
         Stores `keys` for each variate alongside the `$($T)` `d`.
 
@@ -24,14 +24,18 @@ for T in (:Distribution, :Sampleable)
         """
         @auto_hash_equals struct $KeyedT{F<:VariateForm, S<:ValueSupport, D<:$T{F, S}} <: $T{F, S}
             d::D
-            keys::Tuple{AbstractVector}
+            keys::Tuple{Vararg{AbstractVector}}
 
-            function $KeyedT(d::$T{F, S}, keys::Tuple{AbstractVector}) where {F, S}
-                # TODO `size` for MatrixDistributions
-                length(d) == length(keys[1]) || throw(DimensionMismatch(
-                        "number of keys ($(length(keys))) must match " *
-                        "number of variates ($(length(d)))"
-                    ))
+            function $KeyedT(d::$T{F, S}, keys::Tuple{Vararg{AbstractVector}}) where {F, S}
+                length(d) == prod(length, keys) || throw(DimensionMismatch(
+                    "number of keys ($(prod(length, keys))) must match " *
+                    "number of variates ($(length(d)))"))
+
+                if F == Matrixvariate
+                    map(v -> length(v), keys) == size(d) || throw(ArgumentError(
+                        "lengths of key vectors must match size of distribution"))
+                end
+
                 return new{F, S, typeof(d)}(d, keys)
             end
         end
@@ -94,6 +98,10 @@ end
 
 Base.length(d::KeyedDistOrSampleable) = length(distribution(d))
 
+function Distributions.size(d::KeyedDistribution{F}) where F<:Matrixvariate
+    return size(distribution(d))
+end
+
 Distributions.sampler(d::KeyedDistribution) = sampler(distribution(d))
 
 Base.eltype(d::KeyedDistribution) = eltype(distribution(d))
@@ -101,13 +109,25 @@ Base.eltype(d::KeyedDistribution) = eltype(distribution(d))
 Distributions._logpdf(d::KeyedDistribution, x::AbstractArray) =
     Distributions._logpdf(distribution(d), x)
 
-# Also need to overload `rand` methods to return a KeyedArray
+# Also need to overload `rand` methods to return KeyedArrays
 
-Base.rand(rng::AbstractRNG, d::KeyedDistOrSampleable) =
-    KeyedArray(rand(rng, distribution(d)), axiskeys(d))
+function Base.rand(rng::AbstractRNG, d::KeyedDistOrSampleable)
+    sample = rand(rng, distribution(d))
+    ndims(sample) == 0 && return sample  # univariate
+    return KeyedArray(sample, axiskeys(d))
+end
 
-Base.rand(rng::AbstractRNG, d::KeyedDistOrSampleable, n::Int) =
-    KeyedArray(rand(rng, distribution(d), n), (first(axiskeys(d)), Base.OneTo(n)))
+function Base.rand(rng::AbstractRNG, d::KeyedDistOrSampleable, n::Int)
+    samples = rand(rng, distribution(d), n)
+    ndims(samples) == 1 && return KeyedArray(samples, Base.OneTo(n))  # univariate
+    return KeyedArray(samples, (first(axiskeys(d)), Base.OneTo(n)))
+end
+
+function Base.rand(rng::AbstractRNG, d::KeyedDistribution{F}, n::Int) where F<:Matrixvariate
+    # Distributions.rand returns a vector of matrices
+    samples = [KeyedArray(x, axiskeys(d)) for x in rand(rng, distribution(d), n)]
+    return KeyedArray(samples, Base.OneTo(n))
+end
 
 # Statistics functions for Distribution
 

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -114,7 +114,7 @@ Distributions.sampler(d::KeyedDistribution) = sampler(distribution(d))
 Base.eltype(d::KeyedDistribution) = eltype(distribution(d))
 
 function Distributions._logpdf(d::KeyedDistribution, x::AbstractArray)
-    # TODO support KeyedArray as parameter of `Distribution`
+    # Does not support KeyedArray as parameter of Distribution
     # https://github.com/mcabbott/AxisKeys.jl/issues/54
     return Distributions._logpdf(distribution(d), x)
 end

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -13,15 +13,15 @@ export axiskeys, distribution
 for T in (:Distribution, :Sampleable)
     KeyedT = Symbol(:Keyed, T)
     @eval begin
+        """
+            $($KeyedT)(d<:$($T), keys::AbstractVector)
+
+        Stores `keys` for each variate alongside the `$($T)` `d`.
+        """
         @auto_hash_equals struct $KeyedT{F<:VariateForm, S<:ValueSupport, D<:$T{F, S}} <: $T{F, S}
             d::D
             keys::AbstractVector
 
-            """
-                $($KeyedT)(d<:$($T), keys::AbstractVector)
-
-            Stores `keys` for each variate alongside the `$($T)` `d`.
-            """
             function $KeyedT(d::$T{F, S}, keys::AbstractVector) where {F, S}
                 length(d) == length(keys) || throw(DimensionMismatch(
                         "number of keys ($(length(keys))) must match " *

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -17,10 +17,10 @@ for T in (:Distribution, :Sampleable)
         """
             $($KeyedT)(d<:$($T), keys::Tuple{Vararg{AbstractVector}})
 
-        Stores `keys` for each variate alongside the [`$($T)`](@ref) `d`,
-        supporting all of the common functions of a [`$($T)`](@ref).
-        Common functions that return an [`AbstractArray`](@ref), such as [`rand`](@ref),
-        will return a [`KeyedArray`](@ref) with keys derived from the `$($T)`.
+        Stores `keys` for each variate alongside the `$($T)` `d`,
+        supporting all of the common functions of a `$($T)`.
+        Common functions that return an `AbstractArray`, such as `rand`,
+        will return a `KeyedArray` with keys derived from the `$($T)`.
 
         The type of `keys` is restricted to be consistent with
         [AxisKeys.jl](https://github.com/mcabbott/AxisKeys.jl).

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -113,8 +113,10 @@ Distributions.sampler(d::KeyedDistribution) = sampler(distribution(d))
 
 Base.eltype(d::KeyedDistribution) = eltype(distribution(d))
 
-Distributions._logpdf(d::KeyedDistribution, x::AbstractArray) =
-    Distributions._logpdf(distribution(d), x)
+function Distributions._logpdf(d::KeyedDistribution, x::AbstractArray)
+    # TODO issue for inner KeyedArray parameter
+    return Distributions._logpdf(distribution(d), x)
+end
 
 # Also need to overload `rand` methods to return KeyedArrays
 
@@ -142,8 +144,10 @@ Distributions.mean(d::KeyedDistribution) = KeyedArray(mean(distribution(d)), axi
 
 Distributions.var(d::KeyedDistribution) = KeyedArray(var(distribution(d)), axiskeys(d))
 
-Distributions.cov(d::KeyedDistribution) =
-    KeyedArray(cov(distribution(d)), (first(axiskeys(d)), first(axiskeys(d))))
+function Distributions.cov(d::KeyedDistribution)
+    keys = vcat(axiskeys(d)...)
+    return KeyedArray(cov(distribution(d)), (keys, keys))
+end
 
 Distributions.entropy(d::KeyedDistribution) = entropy(distribution(d))
 Distributions.entropy(d::KeyedDistribution, b::Real) = entropy(distribution(d), b)

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -34,16 +34,10 @@ for T in (:Distribution, :Sampleable)
             keys::Tuple{Vararg{AbstractVector}}
 
             function $KeyedT(d::$T{F, S}, keys::Tuple{Vararg{AbstractVector}}) where {F, S}
-                length(d) == prod(length, keys) || throw(ArgumentError(
-                    "number of keys ($(prod(length, keys))) must match " *
-                    "number of variates ($(length(d)))"))
-
-                if F == Matrixvariate  # TODO consider dispatch for this
-                    lengths = map(length, keys)
-                    lengths == size(d) || throw(ArgumentError(
-                        "lengths of key vectors $(lengths) must match " *
-                        "size of distribution $(size(d))"))
-                end
+                key_lengths = map(length, keys)
+                key_lengths == _size(d) || throw(ArgumentError(
+                    "lengths of key vectors $key_lengths must match " *
+                    "size of distribution $(_size(d))"))
 
                 return new{F, S, typeof(d)}(d, keys)
             end
@@ -58,6 +52,9 @@ for T in (:Distribution, :Sampleable)
         $KeyedT(d::$T{F, S}, keys::AbstractVector) where {F, S} = $KeyedT(d, (keys, ))
     end
 end
+
+_size(d) = (length(d),)
+_size(d::Sampleable{<:Matrixvariate}) = size(d)
 
 """
     KeyedDistribution(d::Distribution)

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -21,6 +21,9 @@ for T in (:Distribution, :Sampleable)
         univariate and multivariate distributions, and 2 for matrix-variate distributions.
 
         The length of each vector in `keys` must match the length along each dimension.
+
+        The type of `keys` is restricted to be consistent with
+        AxisKeys.jl (https://github.com/mcabbott/AxisKeys.jl)
         """
         @auto_hash_equals struct $KeyedT{F<:VariateForm, S<:ValueSupport, D<:$T{F, S}} <: $T{F, S}
             d::D
@@ -43,7 +46,7 @@ for T in (:Distribution, :Sampleable)
         """
             $($KeyedT)(d<:$($T), keys::AbstractVector)
 
-        Constructor for $($KeyedT) with one dimension of variates.
+        Constructor for [`$($KeyedT)`](@ref) with one dimension of variates.
         The elements of `keys` correspond to the variates of the distribution.
         """
         $KeyedT(d::$T{F, S}, keys::AbstractVector) where {F, S} = $KeyedT(d, (keys, ))
@@ -53,7 +56,8 @@ end
 """
     KeyedDistribution(d::Distribution)
 
-Constructs a [`KeyedDistribution`](@ref) using the keys of the first field stored in `d`.
+Constructs a [`KeyedDistribution`](@ref) using the keys of the first field stored in `d`,
+or if there are no keys, `1:n` for the length `n` of each dimension.
 """
 function KeyedDistribution(d::Distribution)
     first_field = getfield(d, 1)

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -114,7 +114,8 @@ Distributions.sampler(d::KeyedDistribution) = sampler(distribution(d))
 Base.eltype(d::KeyedDistribution) = eltype(distribution(d))
 
 function Distributions._logpdf(d::KeyedDistribution, x::AbstractArray)
-    # TODO issue for inner KeyedArray parameter
+    # TODO support KeyedArray as parameter of `Distribution`
+    # https://github.com/mcabbott/AxisKeys.jl/issues/54
     return Distributions._logpdf(distribution(d), x)
 end
 

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -1,5 +1,119 @@
 module KeyedDistributions
 
-# Write your package code here.
+using AutoHashEquals
+using AxisKeys
+using AxisKeys: keyless
+using Distributions
+using Random: AbstractRNG
+
+export KeyedDistribution, KeyedSampleable
+export axiskeys, distribution
+
+
+for T in (:Distribution, :Sampleable)
+    KeyedT = Symbol(:Keyed, T)
+    @eval begin
+        @auto_hash_equals struct $KeyedT{F, S, D<:$T{F, S}} <: $T{F, S}
+            d::D
+            keys::AbstractVector
+
+            """
+            $($KeyedT)(d<:$($T), keys::AbstractVector)
+
+            Stores `keys` for each variate alongside the `$($T)` `d`.
+            """
+            function $KeyedT(d::$T{F, S}, keys::AbstractVector) where {F, S}
+                length(d) == length(keys) || throw(DimensionMismatch(
+                        "number of keys ($(length(keys))) must match " *
+                        "number of variates ($(length(d)))"
+                    ))
+                return new{F, S, typeof(d)}(d, keys)
+            end
+        end
+    end
+end
+
+"""
+    KeyedDistribution(d::Distribution)
+
+Constructs a [`KeyedDistribution`](@ref) using keys stored in `d`.
+The keys are copied from the first axis of the first parameter in `d`.
+"""
+function KeyedDistribution(d::D) where D <: Distribution
+    first_param = getfield(d, 1)
+    keys = first(axiskeys(first_param))  # axiskeys guaranteed to be Tuple{AbstractVector}?
+    return KeyedDistribution(d, keys)
+end
+
+const KeyedDistOrSampleable = Union{KeyedDistribution, KeyedSampleable}
+
+# Access methods
+
+"""
+    distribution(::KeyedDistribution) -> Distribution
+    distribution(::KeyedSampleable{F, S, D}) -> D
+
+Return the wrapped distribution.
+"""
+distribution(d::KeyedDistOrSampleable) = d.d
+
+# AxisKeys functionality
+
+Base.parent(d::KeyedDistOrSampleable) = d.d
+
+AxisKeys.keyless(d::KeyedDistOrSampleable) = parent(d)
+
+"""
+    axiskeys(s::Sampleable)
+
+Return the keys for the variates of the Sampleable.
+For an [`KeyedDistribution`](@ref) or [`KeyedSampleable`](@ref) this
+is the keys it was constructed with.
+For any other `Sampleable` this is equal to `1:length(s)`.
+"""
+AxisKeys.axiskeys(d::KeyedDistOrSampleable) = tuple(d.keys)
+AxisKeys.axiskeys(d::Sampleable) = tuple(Base.OneTo(length(d)))
+
+# Standard functions to overload for new Distribution and/or Sampleable
+# https://juliastats.org/Distributions.jl/latest/extends/#Create-a-Distribution
+
+Distributions.sampler(d::KeyedDistOrSampleable) = sampler(keyless(d))
+
+function Distributions._rand!(
+    rng::AbstractRNG,
+    d::KeyedDistOrSampleable,
+    x::AbstractVector{T}
+) where T<:Real
+    sample = Distributions._rand!(rng, parent(d), x)
+    return KeyedArray(sample, axiskeys(d))
+end
+
+function Distributions._logpdf(d::KeyedDistOrSampleable, x::AbstractArray)
+    return Distributions._logpdf(parent(d), x)
+end
+
+Base.length(d::KeyedDistOrSampleable) = length(keyless(d))
+
+Base.eltype(d::KeyedDistOrSampleable) = eltype(keyless(d))
+
+# Also need to overload `rand` methods to return a KeyedArray
+
+Base.rand(rng::AbstractRNG, d::KeyedDistOrSampleable) =
+    KeyedArray(rand(rng, parent(d)), axiskeys(d))
+
+Base.rand(rng::AbstractRNG, d::KeyedDistOrSampleable, n::Int) =
+    KeyedArray(rand(rng, parent(d), n), (first(axiskeys(d)), Base.OneTo(n)))
+
+# Statistics functions
+
+Distributions.mean(d::KeyedDistOrSampleable) = KeyedArray(mean(keyless(d)), axiskeys(d))
+
+Distributions.var(d::KeyedDistOrSampleable) = KeyedArray(var(keyless(d)), axiskeys(d))
+
+Distributions.cov(d::KeyedDistOrSampleable) =
+    KeyedArray(cov(keyless(d)), (first(axiskeys(d)), first(axiskeys(d))))
+
+Distributions.entropy(d::KeyedDistOrSampleable) = entropy(keyless(d))
+Distributions.entropy(d::KeyedDistOrSampleable, b::Real) = entropy(keyless(d), b)
 
 end

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -102,8 +102,8 @@ AxisKeys.axiskeys(d::KeyedDistOrSampleable) = d.keys
 function Distributions._rand!(
     rng::AbstractRNG,
     d::KeyedDistOrSampleable,
-    x::AbstractVector{T}
-) where T<:Real
+    x::AbstractVector{<:Real}
+)
     sample = Distributions._rand!(rng, distribution(d), x)
     return KeyedArray(sample, axiskeys(d))
 end

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -75,9 +75,7 @@ AxisKeys.axiskeys(d::KeyedDistOrSampleable) = tuple(d.keys)
 AxisKeys.axiskeys(d::Sampleable) = tuple(Base.OneTo(length(d)))
 
 # Standard functions to overload for new Distribution and/or Sampleable
-# https://juliastats.org/Distributions.jl/latest/extends/#Create-a-Distribution
-
-Distributions.sampler(d::KeyedDistOrSampleable) = sampler(keyless(d))
+# https://juliastats.org/Distributions.jl/latest/extends/#Create-New-Samplers-and-Distributions
 
 function Distributions._rand!(
     rng::AbstractRNG,
@@ -88,13 +86,14 @@ function Distributions._rand!(
     return KeyedArray(sample, axiskeys(d))
 end
 
-function Distributions._logpdf(d::KeyedDistOrSampleable, x::AbstractArray)
-    return Distributions._logpdf(parent(d), x)
-end
-
 Base.length(d::KeyedDistOrSampleable) = length(keyless(d))
 
-Base.eltype(d::KeyedDistOrSampleable) = eltype(keyless(d))
+Distributions.sampler(d::KeyedDistribution) = sampler(keyless(d))
+
+Base.eltype(d::KeyedDistribution) = eltype(keyless(d))
+
+Distributions._logpdf(d::KeyedDistribution, x::AbstractArray) =
+    Distributions._logpdf(parent(d), x)
 
 # Also need to overload `rand` methods to return a KeyedArray
 
@@ -104,16 +103,16 @@ Base.rand(rng::AbstractRNG, d::KeyedDistOrSampleable) =
 Base.rand(rng::AbstractRNG, d::KeyedDistOrSampleable, n::Int) =
     KeyedArray(rand(rng, parent(d), n), (first(axiskeys(d)), Base.OneTo(n)))
 
-# Statistics functions
+# Statistics functions for Distribution
 
-Distributions.mean(d::KeyedDistOrSampleable) = KeyedArray(mean(keyless(d)), axiskeys(d))
+Distributions.mean(d::KeyedDistribution) = KeyedArray(mean(keyless(d)), axiskeys(d))
 
-Distributions.var(d::KeyedDistOrSampleable) = KeyedArray(var(keyless(d)), axiskeys(d))
+Distributions.var(d::KeyedDistribution) = KeyedArray(var(keyless(d)), axiskeys(d))
 
-Distributions.cov(d::KeyedDistOrSampleable) =
+Distributions.cov(d::KeyedDistribution) =
     KeyedArray(cov(keyless(d)), (first(axiskeys(d)), first(axiskeys(d))))
 
-Distributions.entropy(d::KeyedDistOrSampleable) = entropy(keyless(d))
-Distributions.entropy(d::KeyedDistOrSampleable, b::Real) = entropy(keyless(d), b)
+Distributions.entropy(d::KeyedDistribution) = entropy(keyless(d))
+Distributions.entropy(d::KeyedDistribution, b::Real) = entropy(keyless(d), b)
 
 end

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -72,7 +72,6 @@ is the keys it was constructed with.
 For any other `Sampleable` this is equal to `1:length(s)`.
 """
 AxisKeys.axiskeys(d::KeyedDistOrSampleable) = tuple(d.keys)
-AxisKeys.axiskeys(d::Sampleable) = tuple(Base.OneTo(length(d)))
 
 # Standard functions to overload for new Distribution and/or Sampleable
 # https://juliastats.org/Distributions.jl/latest/extends/#Create-New-Samplers-and-Distributions

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -162,4 +162,21 @@ end
 Distributions.entropy(d::KeyedDistribution) = entropy(distribution(d))
 Distributions.entropy(d::KeyedDistribution, b::Real) = entropy(distribution(d), b)
 
+# Univariate Distributions only
+
+for f in (:logpdf, :quantile, :mgf, :cf)
+    @eval Distributions.$f(d::KeyedDistribution{<:Univariate}, x) = $f(distribution(d), x)
+end
+
+for f in (:minimum, :maximum, :modes, :mode, :skewness, :kurtosis)
+    @eval Distributions.$f(d::KeyedDistribution{<:Univariate}) = $f(distribution(d))
+end
+
+# Needed to avoid method ambiguity
+Distributions.cdf(d::KeyedDistribution{<:Univariate}, x::Real) = cdf(distribution(d), x)
+
+function Distributions.insupport(d::KeyedDistribution{<:Univariate}, x::Real)
+    return insupport(distribution(d), x)
+end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -100,13 +100,20 @@ using Test
         keys = ([:a, :b, :c], )
         kd = KeyedDistribution(d, keys)
 
-        @testset "Inner keys constructor" begin
-            kd2 = KeyedDistribution(MvNormal(KeyedArray(m, keys), s))
+        @testset "no-keys constructor" begin
+            @testset "inner keys" begin
+                kd2 = KeyedDistribution(MvNormal(KeyedArray(m, keys), s))
 
-            @test kd2 isa Distribution
-            @test distribution(kd2) == d
-            @test axiskeys(kd2) == keys
-            @test mean(kd2) == m
+                @test kd2 isa Distribution
+                @test distribution(kd2) == d
+                @test axiskeys(kd2) == keys
+                @test mean(kd2) == m
+            end
+
+            @testset "default keys" begin
+                kd2 = KeyedDistribution(MvNormal(m, s))
+                @test axiskeys(kd2) == (Base.OneTo(3), )
+            end
         end
 
         @testset "base functions" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,11 +3,12 @@ using Distributions
 using KeyedDistributions
 using LinearAlgebra
 using Random
+using StableRNGs
 using Statistics
 using Test
 
 @testset "KeyedDistributions.jl" begin
-    X = rand(MersenneTwister(1234), 10, 3)
+    X = rand(StableRNG(1234), 10, 3)
     m = vec(mean(X; dims=1))
     s = cov(X; dims=1)
     d = MvNormal(m, s)
@@ -31,13 +32,13 @@ using Test
 
             @testset "sampling" begin
                 # Samples from the distribution both wrapped and unwrapped should be the same.
-                @test rand(MersenneTwister(1), d) == rand(MersenneTwister(1), kd)
-                @test rand(MersenneTwister(1), d, 3) == rand(MersenneTwister(1), kd, 3)
+                @test rand(StableRNG(1), d) == rand(StableRNG(1), kd)
+                @test rand(StableRNG(1), d, 3) == rand(StableRNG(1), kd, 3)
 
-                rng = MersenneTwister(1)
+                rng = StableRNG(1)
 
                 @testset "_rand!" begin
-                    expected = [0.6048058078690228, 0.5560878435408364, 0.41599188102577894]
+                    expected = [0.4209843517343097, 0.40546557072031986, 0.5573596971895245]
                     observed = Distributions._rand!(rng, kd, zeros(Float64, 3))
                     @test observed isa KeyedArray
                     @test isapprox(observed, expected)
@@ -46,7 +47,7 @@ using Test
                 end
 
                 @testset "one-sample method" begin
-                    expected = [0.5333595810495181, 0.12636240168741192, 0.579000443516295]
+                    expected = [0.3308452209411066, -0.10785874526873923, 0.3177486760818843]
                     observed = rand(rng, kd)
                     @test observed isa KeyedArray
                     @test isapprox(observed, expected)
@@ -56,9 +57,9 @@ using Test
 
                 @testset "multi-sample method" begin
                     expected = [
-                        1.0686337176543628 0.6359475064225186;
-                        -0.44724174718706566 0.6246866736932383;
-                        0.914066493850531 0.9897659744431875
+                        0.8744990592397803 0.6468838205306433;
+                        0.5919869675852324 0.04861847876961256;
+                        0.24068367188141987 0.3277215089605162
                     ]
                     observed = rand(rng, kd, 2)
                     @test observed isa KeyedArray

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,17 +9,6 @@ using Test
 @testset "KeyedDistributions.jl" begin
     # Write your tests here.
 
-    @testset "Inner keys constructor" begin
-        keys = [:a, :b]
-        m = KeyedArray([1., 2.], keys)
-        d = MvNormal(m, [1., 1.])
-        kd = KeyedDistribution(d)
-
-        @test distribution(kd) == d
-        @test axiskeys(kd) == (keys, )
-        @test mean(kd) == m
-    end
-
     @testset "Common" begin
         X = rand(MersenneTwister(1234), 10, 5)
         m = vec(mean(X; dims=1))
@@ -39,32 +28,6 @@ using Test
                 @test eltype(kd) == eltype(d) == Float64
                 @test isequal(kd, T(d, [:a, :b, :c, :d, :e]))
                 @test ==(kd, T(d, keys))
-            end
-
-            @testset "statistical functions" begin
-                @test mean(kd) isa KeyedArray{Float64, 1}
-                @test parent(mean(kd)) == mean(d) == m
-                # @test axisnames(mean(kd)) == (:variates,)
-
-                @test var(kd) isa KeyedArray{Float64, 1}
-                @test parent(var(kd)) == var(d) == diag(s)
-                # @test axisnames(var(kd)) == (:variates,)
-
-                @test cov(kd) isa KeyedArray{Float64, 2}
-                @test parent(cov(kd)) == cov(d) == s
-                # @test axisnames(cov(kd)) == (:variates, :variates_)
-
-                @test entropy(kd) isa Number
-                @test entropy(kd) == entropy(d)
-                @test entropy(kd, 2) == entropy(d, 2)
-
-                @test Distributions._logpdf(kd, m) isa Number
-                @test Distributions._logpdf(kd, m) == Distributions._logpdf(d, m)
-
-                # statistical functions commute with parent on KeyedArray/KeyedDistribution
-                for f in (mean, var, cov)
-                    @test f(parent(kd)) == parent(f(kd))
-                end
             end
 
             @testset "sampling" begin
@@ -105,6 +68,52 @@ using Test
                     # @test axisnames(observed) == (:variates, :samples)
                     @test first(axiskeys(observed)) == first(axiskeys(kd))
                 end
+            end
+        end
+    end
+
+    @testset "KeyedDistribution only" begin
+        @testset "Inner keys constructor" begin
+            keys = [:a, :b]
+            m = KeyedArray([1., 2.], keys)
+            d = MvNormal(m, [1., 1.])
+            kd = KeyedDistribution(d)
+
+            @test distribution(kd) == d
+            @test axiskeys(kd) == (keys, )
+            @test mean(kd) == m
+        end
+
+        @testset "statistical functions" begin
+            X = rand(MersenneTwister(1234), 10, 5)
+            m = vec(mean(X; dims=1))
+            s = cov(X; dims=1)
+            d = MvNormal(m, s)
+            keys = [:a, :b, :c, :d, :e]
+            kd = KeyedDistribution(d, keys)
+
+            @test mean(kd) isa KeyedArray{Float64, 1}
+            @test parent(mean(kd)) == mean(d) == m
+            # @test axisnames(mean(kd)) == (:variates,)
+
+            @test var(kd) isa KeyedArray{Float64, 1}
+            @test parent(var(kd)) == var(d) == diag(s)
+            # @test axisnames(var(kd)) == (:variates,)
+
+            @test cov(kd) isa KeyedArray{Float64, 2}
+            @test parent(cov(kd)) == cov(d) == s
+            # @test axisnames(cov(kd)) == (:variates, :variates_)
+
+            @test entropy(kd) isa Number
+            @test entropy(kd) == entropy(d)
+            @test entropy(kd, 2) == entropy(d, 2)
+
+            @test Distributions._logpdf(kd, m) isa Number
+            @test Distributions._logpdf(kd, m) == Distributions._logpdf(d, m)
+
+            # statistical functions commute with parent on KeyedArray/KeyedDistribution
+            for f in (mean, var, cov)
+                @test f(parent(kd)) == parent(f(kd))
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,26 +7,25 @@ using Statistics
 using Test
 
 @testset "KeyedDistributions.jl" begin
-    # Write your tests here.
+    X = rand(MersenneTwister(1234), 10, 3)
+    m = vec(mean(X; dims=1))
+    s = cov(X; dims=1)
+    d = MvNormal(m, s)
+    keys = [:a, :b, :c]
+    kd = KeyedDistribution(d, keys)
 
     @testset "Common" begin
-        X = rand(MersenneTwister(1234), 10, 5)
-        m = vec(mean(X; dims=1))
-        s = cov(X; dims=1)
-        d = MvNormal(m, s)
-        keys = [:a, :b, :c, :d, :e]
-
-        @testset for T in (KeyedDistribution, KeyedSampleable)
+        @testset "$T" for T in (KeyedDistribution, KeyedSampleable)
             kd = T(d, keys)
 
             @testset "base functions" begin
                 @test kd isa Sampleable
                 @test distribution(kd) == d
                 @test parent(kd) == d
+                @test AxisKeys.keyless(kd) == d
                 @test axiskeys(kd) == (keys, )
-                @test length(kd) == length(d) == 5
-                @test eltype(kd) == eltype(d) == Float64
-                @test isequal(kd, T(d, [:a, :b, :c, :d, :e]))
+                @test length(kd) == length(d) == 3
+                @test isequal(kd, T(d, [:a, :b, :c]))
                 @test ==(kd, T(d, keys))
             end
 
@@ -38,71 +37,63 @@ using Test
                 rng = MersenneTwister(1)
 
                 @testset "one-sample method" begin
-                    expected = [
-                        0.6048058078690228,
-                        0.5560878435408365,
-                        0.41599188102577894,
-                        0.4756226986245742,
-                        0.15366818427047801,
-                    ]
+                    expected = [0.6048058078690228, 0.5560878435408364, 0.41599188102577894]
                     observed = rand(rng, kd)
                     @test observed isa KeyedArray
                     @test isapprox(observed, expected)
                     @test isapprox(observed(:a), expected[1])
-                    # @test axisnames(observed) == (:variates,)
                     @test first(axiskeys(observed)) == first(axiskeys(kd))
                 end
 
                 @testset "multi-sample method" begin
                     expected = [
-                        0.6080151671094673,
-                        1.2415182218538203,
-                        -4.4285504138930065e-5,
-                        0.7298398256256964,
-                        0.2103467702699237,
+                        0.5333595810495181 1.0686337176543628;
+                        0.12636240168741192 -0.44724174718706566;
+                        0.579000443516295 0.914066493850531
                     ]
-                    observed = rand(rng, kd, 1)
+                    observed = rand(rng, kd, 2)
                     @test observed isa KeyedArray
                     @test isapprox(observed, expected)
-                    @test isapprox(observed(:a), [expected[1]])
-                    # @test axisnames(observed) == (:variates, :samples)
+                    @test isapprox(observed(:a), expected[1, :])
                     @test first(axiskeys(observed)) == first(axiskeys(kd))
                 end
             end
         end
     end
 
+    @testset "Non-Distribution Sampleable only" begin
+        sampler = Distributions.MultinomialSampler(3, [0.1, 0.2, 0.3])
+
+        @test axiskeys(sampler) == (Base.OneTo(3), )
+    end
+
     @testset "KeyedDistribution only" begin
         @testset "Inner keys constructor" begin
-            keys = [:a, :b]
-            m = KeyedArray([1., 2.], keys)
-            d = MvNormal(m, [1., 1.])
-            kd = KeyedDistribution(d)
+            kd2 = KeyedDistribution(MvNormal(KeyedArray(m, keys), s))
 
-            @test distribution(kd) == d
-            @test axiskeys(kd) == (keys, )
-            @test mean(kd) == m
+            @test kd2 isa Distribution
+            @test distribution(kd2) == d
+            @test axiskeys(kd2) == (keys, )
+            @test mean(kd2) == m
+        end
+
+        kd = KeyedDistribution(d, keys)
+
+        @testset "base functions" begin
+            @test kd isa Distribution
+            @test sampler(kd) == sampler(d)
+            @test eltype(kd) == eltype(d) == Float64
         end
 
         @testset "statistical functions" begin
-            X = rand(MersenneTwister(1234), 10, 5)
-            m = vec(mean(X; dims=1))
-            s = cov(X; dims=1)
-            d = MvNormal(m, s)
-            keys = [:a, :b, :c, :d, :e]
-            kd = KeyedDistribution(d, keys)
-
             @test mean(kd) isa KeyedArray{Float64, 1}
             @test parent(mean(kd)) == mean(d) == m
-            # @test axisnames(mean(kd)) == (:variates,)
 
             @test var(kd) isa KeyedArray{Float64, 1}
             @test parent(var(kd)) == var(d) == diag(s)
-            # @test axisnames(var(kd)) == (:variates,)
 
             @test cov(kd) isa KeyedArray{Float64, 2}
             @test parent(cov(kd)) == cov(d) == s
-            # @test axisnames(cov(kd)) == (:variates, :variates_)
 
             @test entropy(kd) isa Number
             @test entropy(kd) == entropy(d)
@@ -120,6 +111,7 @@ using Test
 
     @testset "Invalid keys $T" for T in (KeyedDistribution, KeyedSampleable)
         @test_throws DimensionMismatch T(MvNormal(ones(3)), ["foo"])
+        @test_throws MethodError T(MvNormal(ones(3)), (:a, :b, :c))  # because Tuple
     end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,7 +52,7 @@ using Test
             end
 
             @testset "sampling" begin
-                # Samples from the distribution both wrapped and unwrapped should be the same.
+                # Samples from the distribution both wrapped and unwrapped are the same
                 @test rand(StableRNG(1), d) == rand(StableRNG(1), kd)
                 @test rand(StableRNG(1), d, 3) == rand(StableRNG(1), kd, 3)
 
@@ -68,7 +68,7 @@ using Test
                 end
 
                 @testset "one-sample method" begin
-                    expected = [0.3308452209411066, -0.10785874526873923, 0.3177486760818843]
+                    expected = [0.3308452209411066, -0.1078587452687392, 0.3177486760818843]
                     observed = rand(rng, kd)
                     @test observed isa KeyedArray
                     @test isapprox(observed, expected)
@@ -98,9 +98,9 @@ using Test
         s = cov(X; dims=1)
         d = MvNormal(m, s)
         keys = ([:a, :b, :c], )
-        keys_kd = KeyedDistribution(d, keys)
-        no_keys_kd = KeyedDistribution(MvNormal(KeyedArray(m, keys), s))
-        kds = (keys=keys_kd, no_keys=no_keys_kd)
+        kd_keys = KeyedDistribution(d, keys)
+        kd_no_keys = KeyedDistribution(MvNormal(KeyedArray(m, keys), s))
+        kds = (keys=kd_keys, no_keys=kd_no_keys)
 
         @testset "$case" for case in (:keys, :no_keys)
             kd = kds[case]
@@ -144,13 +144,6 @@ using Test
             kd = KeyedDistribution(MvNormal(m, s))
             @test axiskeys(kd) == (Base.OneTo(3), )
         end
-    end
-
-    @testset "Invalid keys $T" for T in (KeyedDistribution, KeyedSampleable)
-        # Wrong number of keys
-        @test_throws DimensionMismatch T(MvNormal(ones(3)), ["foo"])
-        # AxisKeys requires key vectors to be AbstractVector
-        @test_throws MethodError T(MvNormal(ones(3)), (:a, :b, :c))
     end
 
     @testset "Distributions types" begin
@@ -224,5 +217,14 @@ using Test
             @test rand(rng, ksamp) == [3, 2]
             @test rand(rng, ksamp, 2) == [1 1; 4 4]
         end
+    end
+
+    @testset "Invalid keys $T" for T in (KeyedDistribution, KeyedSampleable)
+        # Wrong number of keys
+        @test_throws ArgumentError T(MvNormal(ones(3)), ["foo"])
+        # Wrong key lengths
+        @test_throws ArgumentError T(Wishart(7.0, Matrix(1.0I, 2, 2)), (["foo"], ["bar"]))
+        # AxisKeys requires key vectors to be AbstractVector
+        @test_throws MethodError T(MvNormal(ones(3)), (:a, :b, :c))
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,116 @@
+using AxisKeys
+using Distributions
 using KeyedDistributions
+using LinearAlgebra
+using Random
+using Statistics
 using Test
 
 @testset "KeyedDistributions.jl" begin
     # Write your tests here.
+
+    @testset "Inner keys constructor" begin
+        keys = [:a, :b]
+        m = KeyedArray([1., 2.], keys)
+        d = MvNormal(m, [1., 1.])
+        kd = KeyedDistribution(d)
+
+        @test distribution(kd) == d
+        @test axiskeys(kd) == (keys, )
+        @test mean(kd) == m
+    end
+
+    @testset "Common" begin
+        X = rand(MersenneTwister(1234), 10, 5)
+        m = vec(mean(X; dims=1))
+        s = cov(X; dims=1)
+        d = MvNormal(m, s)
+        keys = [:a, :b, :c, :d, :e]
+
+        @testset for T in (KeyedDistribution, KeyedSampleable)
+            kd = T(d, keys)
+
+            @testset "base functions" begin
+                @test kd isa Sampleable
+                @test distribution(kd) == d
+                @test parent(kd) == d
+                @test axiskeys(kd) == (keys, )
+                @test length(kd) == length(d) == 5
+                @test eltype(kd) == eltype(d) == Float64
+                @test isequal(kd, T(d, [:a, :b, :c, :d, :e]))
+                @test ==(kd, T(d, keys))
+            end
+
+            @testset "statistical functions" begin
+                @test mean(kd) isa KeyedArray{Float64, 1}
+                @test parent(mean(kd)) == mean(d) == m
+                # @test axisnames(mean(kd)) == (:variates,)
+
+                @test var(kd) isa KeyedArray{Float64, 1}
+                @test parent(var(kd)) == var(d) == diag(s)
+                # @test axisnames(var(kd)) == (:variates,)
+
+                @test cov(kd) isa KeyedArray{Float64, 2}
+                @test parent(cov(kd)) == cov(d) == s
+                # @test axisnames(cov(kd)) == (:variates, :variates_)
+
+                @test entropy(kd) isa Number
+                @test entropy(kd) == entropy(d)
+                @test entropy(kd, 2) == entropy(d, 2)
+
+                @test Distributions._logpdf(kd, m) isa Number
+                @test Distributions._logpdf(kd, m) == Distributions._logpdf(d, m)
+
+                # statistical functions commute with parent on KeyedArray/KeyedDistribution
+                for f in (mean, var, cov)
+                    @test f(parent(kd)) == parent(f(kd))
+                end
+            end
+
+            @testset "sampling" begin
+                # Samples from the distribution both wrapped and unwrapped should be the same.
+                @test rand(MersenneTwister(1), d) == rand(MersenneTwister(1), kd)
+                @test rand(MersenneTwister(1), d, 3) == rand(MersenneTwister(1), kd, 3)
+
+                rng = MersenneTwister(1)
+
+                @testset "one-sample method" begin
+                    expected = [
+                        0.6048058078690228,
+                        0.5560878435408365,
+                        0.41599188102577894,
+                        0.4756226986245742,
+                        0.15366818427047801,
+                    ]
+                    observed = rand(rng, kd)
+                    @test observed isa KeyedArray
+                    @test isapprox(observed, expected)
+                    @test isapprox(observed(:a), expected[1])
+                    # @test axisnames(observed) == (:variates,)
+                    @test first(axiskeys(observed)) == first(axiskeys(kd))
+                end
+
+                @testset "multi-sample method" begin
+                    expected = [
+                        0.6080151671094673,
+                        1.2415182218538203,
+                        -4.4285504138930065e-5,
+                        0.7298398256256964,
+                        0.2103467702699237,
+                    ]
+                    observed = rand(rng, kd, 1)
+                    @test observed isa KeyedArray
+                    @test isapprox(observed, expected)
+                    @test isapprox(observed(:a), [expected[1]])
+                    # @test axisnames(observed) == (:variates, :samples)
+                    @test first(axiskeys(observed)) == first(axiskeys(kd))
+                end
+            end
+        end
+    end
+
+    @testset "Invalid keys $T" for T in (KeyedDistribution, KeyedSampleable)
+        @test_throws DimensionMismatch T(MvNormal(ones(3)), ["foo"])
+    end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,12 +70,6 @@ using Test
         end
     end
 
-    @testset "Non-Distribution Sampleable only" begin
-        sampler = Distributions.MultinomialSampler(3, [0.1, 0.2, 0.3])
-
-        @test axiskeys(sampler) == (Base.OneTo(3), )
-    end
-
     @testset "KeyedDistribution only" begin
         @testset "Inner keys constructor" begin
             kd2 = KeyedDistribution(MvNormal(KeyedArray(m, keys), s))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -235,6 +235,7 @@ using Test
         # Wrong number of keys
         @test_throws ArgumentError T(MvNormal(ones(3)), ["foo"])
         # Wrong key lengths
+        @test_throws ArgumentError T(MvNormal(ones(3)), ([:a, :b, :c], [:x]))
         @test_throws ArgumentError T(Wishart(7.0, Matrix(1.0I, 2, 2)), (["foo"], ["bar"]))
         # AxisKeys requires key vectors to be AbstractVector
         @test_throws MethodError T(MvNormal(ones(3)), (:a, :b, :c))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -126,12 +126,7 @@ using Test
                 @test entropy(kd) == entropy(d)
                 @test entropy(kd, 2) == entropy(d, 2)
 
-                if case == :no_keys
-                    # https://github.com/mcabbott/AxisKeys.jl/issues/54
-                    @test_broken Distributions._logpdf(kd, m) == Distributions._logpdf(d, m)
-                else
-                    @test Distributions._logpdf(kd, m) == Distributions._logpdf(d, m)
-                end
+                @test Distributions._logpdf(kd, m) == Distributions._logpdf(d, m)
 
                 # statistical functions commute with accessor methods
                 for f in (mean, var, cov)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -151,6 +151,23 @@ using Test
             @test axiskeys(kd) == (["variate"], )
             @test length(kd) == length(d) == 1
 
+            @test logpdf(kd, 1) == logpdf(d, 1) ≈ -2.4345006207705726
+            @test cdf(kd, 1) == cdf(d, 1) ≈ 0.9937903346742238
+            @test quantile(kd, 0.5) == quantile(d, 0.5) == 0.5
+            @test insupport(kd, 1) == insupport(d, 1) == true
+            @test mgf(kd, 1) == mgf(d, 1) ≈ 1.6820276496988864
+            @test cf(kd, 0) == cf(d, 0) == 1.0 + 0.0im
+            @test entropy(kd) == entropy(d) ≈ -0.1904993792294276
+            @test entropy(kd, 2) == entropy(d, 2) ≈ -0.27483250970672124
+
+            @test minimum(kd) == minimum(d) == -Inf
+            @test maximum(kd) == maximum(d) == Inf
+            @test modes(kd) == modes(d) == [0.5]
+            @test mode(kd) == mode(d) == 0.5
+            @test skewness(kd) == skewness(d) == 0.0
+            @test kurtosis(kd) == kurtosis(d) == 0.0
+            @test kurtosis(kd, false) == kurtosis(d, false) == 3.0
+
             @test isapprox(rand(rng, kd), 0.39349598502717537)
             @test isapprox(rand(rng, kd, 2), [0.519693102856957, 0.6505773044249047])
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -132,11 +132,9 @@ using Test
             @test cov(kd) isa KeyedArray{Float64, 2}
             @test parent(cov(kd)) == cov(d) == s
 
-            @test entropy(kd) isa Number
             @test entropy(kd) == entropy(d)
             @test entropy(kd, 2) == entropy(d, 2)
 
-            @test Distributions._logpdf(kd, m) isa Number
             @test Distributions._logpdf(kd, m) == Distributions._logpdf(d, m)
 
             # statistical functions commute with accessor methods

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@ using AxisKeys
 using Distributions
 using KeyedDistributions
 using LinearAlgebra
-using Random
 using StableRNGs
 using Statistics
 using Test
@@ -22,8 +21,6 @@ using Test
             @testset "base functions" begin
                 @test kd isa Sampleable
                 @test distribution(kd) == d
-                @test parent(kd) == d
-                @test AxisKeys.keyless(kd) == d
                 @test axiskeys(kd) == (keys, )
                 @test length(kd) == length(d) == 3
                 @test isequal(kd, T(d, [:a, :b, :c]))
@@ -106,9 +103,9 @@ using Test
             @test Distributions._logpdf(kd, m) isa Number
             @test Distributions._logpdf(kd, m) == Distributions._logpdf(d, m)
 
-            # statistical functions commute with parent on KeyedArray/KeyedDistribution
+            # statistical functions commute with accessor methods
             for f in (mean, var, cov)
-                @test f(parent(kd)) == parent(f(kd))
+                @test f(distribution(kd)) == parent(f(kd))
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,8 +36,17 @@ using Test
 
                 rng = MersenneTwister(1)
 
-                @testset "one-sample method" begin
+                @testset "_rand!" begin
                     expected = [0.6048058078690228, 0.5560878435408364, 0.41599188102577894]
+                    observed = Distributions._rand!(rng, kd, zeros(Float64, 3))
+                    @test observed isa KeyedArray
+                    @test isapprox(observed, expected)
+                    @test isapprox(observed(:a), expected[1])
+                    @test first(axiskeys(observed)) == first(axiskeys(kd))
+                end
+
+                @testset "one-sample method" begin
+                    expected = [0.5333595810495181, 0.12636240168741192, 0.579000443516295]
                     observed = rand(rng, kd)
                     @test observed isa KeyedArray
                     @test isapprox(observed, expected)
@@ -47,9 +56,9 @@ using Test
 
                 @testset "multi-sample method" begin
                     expected = [
-                        0.5333595810495181 1.0686337176543628;
-                        0.12636240168741192 -0.44724174718706566;
-                        0.579000443516295 0.914066493850531
+                        1.0686337176543628 0.6359475064225186;
+                        -0.44724174718706566 0.6246866736932383;
+                        0.914066493850531 0.9897659744431875
                     ]
                     observed = rand(rng, kd, 2)
                     @test observed isa KeyedArray

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -161,7 +161,7 @@ using Test
 
             @test kd isa UnivariateDistribution
             @test axiskeys(kd) == (["variate"], )
-            @test length(kd) == 1
+            @test length(kd) == length(d) == 1
 
             @test isapprox(rand(rng, kd), 0.39349598502717537)
             @test isapprox(rand(rng, kd, 2), [0.519693102856957, 0.6505773044249047])
@@ -173,10 +173,11 @@ using Test
             rng = StableRNG(1)
 
             @test md isa MatrixDistribution
-            @test size(md) == (2, 2)
+            @test length(md) == length(d) == 4
+            @test size(md) == size(d) == (2, 2)
             @test axiskeys(md) == (["x1", "x2"], ["y1", "y2"])
 
-            @testset "one-sample method" begin
+            @testset "sample" begin
                 expected = [
                     4.297085163636559 -1.7486034270372186;
                     -1.7486034270372186 8.375810638889545
@@ -188,7 +189,7 @@ using Test
                 @test axiskeys(observed) == axiskeys(md)
             end
 
-            @testset "multi-sample method" begin
+            @testset "multi-sample" begin
                 expected = [
                     [
                         16.39083916144797 4.884197412188479;
@@ -218,7 +219,7 @@ using Test
             @test ksamp isa Sampleable
             @test !(ksamp isa Distribution)
             @test axiskeys(ksamp) == (["number1", "number2"], )
-            @test length(ksamp) == 2
+            @test length(ksamp) == length(samp) == 2
 
             @test rand(rng, ksamp) == [3, 2]
             @test rand(rng, ksamp, 2) == [1 1; 4 4]


### PR DESCRIPTION
This proof of concept for KeyedDistributions extends the AxisKeys.jl ecosystem with `KeyedSampleable` and `KeyedDistribution` types. The types thinly wrap `Sampleable`s with a vector of keys, corresponding to the variates of the `Sampleable`. This is analogous to `KeyedArray` wrapping an array.

Not implemented:

- NamedDims support #2 
- Callable lookup syntax #3 
- Methods to marginalize a distribution #4 
- MixtureModel support #5 