### PR TITLE
Define MvNormalLike and MvTLike constants

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KeyedDistributions"
 uuid = "2576fb08-064d-4cab-b15d-8dda7fcb9a6d"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -3,14 +3,13 @@ module KeyedDistributions
 using AutoHashEquals
 using AxisKeys
 using Distributions
+using Distributions: GenericMvTDist
 using IterTools
 using Random: AbstractRNG
 
 export KeyedDistribution, KeyedSampleable
+export KeyedMvNormal, KeyedGenericMvTDist, MvNormalLike, MvTLike
 export axiskeys, distribution
-
-
-# Constructors
 
 for T in (:Distribution, :Sampleable)
     KeyedT = Symbol(:Keyed, T)
@@ -71,6 +70,13 @@ _keys(x::KeyedArray) = axiskeys(x)
 _keys(x) = map(Base.OneTo, size(x))
 
 const KeyedDistOrSampleable = Union{KeyedDistribution, KeyedSampleable}
+
+# MvNormal and MvT are particularly useful - these make it easier to dispatch
+const KeyedMvNormal = KeyedDistribution{Multivariate, Continuous, <:MvNormal}
+const MvNormalLike = Union{MvNormal, KeyedMvNormal}
+
+const KeyedGenericMvTDist = KeyedDistribution{Multivariate, Continuous, <:GenericMvTDist}
+const MvTLike = Union{GenericMvTDist, KeyedGenericMvTDist}
 
 # Access methods
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,7 +35,7 @@ using Test
             @test KeyedMvNormal <: MvNormalLike
             @test GenericMvTDist <: MvTLike
             @test KeyedGenericMvTDist <: MvTLike
-            @test MvNormal <: MultivariateDistribution
+            @test MvNormalLike <: MultivariateDistribution
             @test MvTLike <: MultivariateDistribution
 
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using AxisKeys
 using Distributions
+using Distributions: GenericMvTDist
 using KeyedDistributions
 using LinearAlgebra
 using StableRNGs
@@ -29,6 +30,14 @@ using Test
 
             # Input not a Distribution
             @test_throws MethodError KeyedDistribution(X, keys)
+
+            @test MvNormal <: MvNormalLike
+            @test KeyedMvNormal <: MvNormalLike
+            @test GenericMvTDist <: MvTLike
+            @test KeyedGenericMvTDist <: MvTLike
+            @test MvNormal <: MultivariateDistribution
+            @test MvTLike <: MultivariateDistribution
+
         end
 
         @testset "1-dimensional constructor" begin


### PR DESCRIPTION
Defining useful constants that we use internally