### PR TITLE
Add marginalise utility for KeyedMvNormal and KeyedMvTDist

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
 AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+PDMatsExtras = "2c7acb1b-7338-470f-b38f-951d2bcb9193"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
@@ -16,6 +17,7 @@ AutoHashEquals = "0.2"
 AxisKeys = "0.1"
 Distributions = "0.24"
 IterTools = "1.3"
+PDMatsExtras = "2.5"
 StableRNGs = "1"
 julia = "1.5"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KeyedDistributions"
 uuid = "2576fb08-064d-4cab-b15d-8dda7fcb9a6d"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,37 +1,169 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[AbstractFFTs]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "051c95d6836228d120f5f4b984dd5aba1624f716"
+uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+version = "0.5.0"
+
+[[Adapt]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "84918055d15b3114ede17ac6a7182f68870c16f7"
+uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "3.3.1"
+
+[[ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+
+[[ArrayInterface]]
+deps = ["IfElse", "LinearAlgebra", "Requires", "SparseArrays", "Static"]
+git-tree-sha1 = "045ff5e1bc8c6fb1ecb28694abba0a0d55b5f4f5"
+uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+version = "3.1.17"
+
+[[Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[AutoHashEquals]]
+git-tree-sha1 = "45bb6705d93be619b81451bb2006b7ee5d4e4453"
+uuid = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
+version = "0.2.0"
+
+[[AxisKeys]]
+deps = ["AbstractFFTs", "CovarianceEstimation", "IntervalSets", "InvertedIndices", "LazyStack", "LinearAlgebra", "NamedDims", "OffsetArrays", "Statistics", "StatsBase", "Tables"]
+git-tree-sha1 = "118c5c2c9f509f503efa05fa2385936bc2cad78d"
+uuid = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
+version = "0.1.16"
+
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[ChainRulesCore]]
+deps = ["Compat", "LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "ea05cadc30c15f9185b61ea418b9d47d53b55bc2"
+uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+version = "0.10.8"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "dc7dedc2c2aa9faf59a55c622760a25cbefbe941"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "3.31.0"
+
+[[CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+
+[[CovarianceEstimation]]
+deps = ["LinearAlgebra", "Statistics", "StatsBase"]
+git-tree-sha1 = "bc3930158d2be029e90b7c40d1371c4f54fa04db"
+uuid = "587fd27a-f159-11e8-2dae-1979310e6154"
+version = "0.2.6"
+
+[[DataAPI]]
+git-tree-sha1 = "dfb3b7e89e395be1e25c2ad6d7690dc29cc53b1d"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.6.0"
+
+[[DataStructures]]
+deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "4437b64df1e0adccc3e5d1adbc3ac741095e4677"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.18.9"
+
+[[DataValueInterfaces]]
+git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
+uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
+version = "1.0.0"
 
 [[Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
 [[Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
+[[Distributions]]
+deps = ["FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SparseArrays", "SpecialFunctions", "Statistics", "StatsBase", "StatsFuns"]
+git-tree-sha1 = "a837fdf80f333415b69684ba8e8ae6ba76de6aaa"
+uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
+version = "0.24.18"
+
 [[DocStringExtensions]]
-deps = ["LibGit2", "Markdown", "Pkg", "Test"]
-git-tree-sha1 = "50ddf44c53698f5e784bbebb3f4b21c5807401b1"
+deps = ["LibGit2"]
+git-tree-sha1 = "a32185f5428d3986f47c2ab78b1f216d5e6cc96f"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.3"
+version = "0.8.5"
 
 [[Documenter]]
 deps = ["Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
-git-tree-sha1 = "3ebb967819b284dc1e3c0422229b58a40a255649"
+git-tree-sha1 = "621850838b3e74dd6dd047b5432d2e976877104e"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.26.3"
+version = "0.27.2"
+
+[[Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
+[[EllipsisNotation]]
+deps = ["ArrayInterface"]
+git-tree-sha1 = "8041575f021cba5a099a456b4163c9a08b566a02"
+uuid = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
+version = "1.1.0"
+
+[[FillArrays]]
+deps = ["LinearAlgebra", "Random", "SparseArrays"]
+git-tree-sha1 = "31939159aeb8ffad1d4d8ee44d07f8558273120a"
+uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
+version = "0.11.7"
 
 [[IOCapture]]
-deps = ["Logging"]
-git-tree-sha1 = "377252859f740c217b936cebcd918a44f9b53b59"
+deps = ["Logging", "Random"]
+git-tree-sha1 = "f7be53659ab06ddc986428d3a9dcc95f6fa6705a"
 uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
-version = "0.1.1"
+version = "0.2.2"
+
+[[IfElse]]
+git-tree-sha1 = "28e837ff3e7a6c3cdb252ce49fb412c8eb3caeef"
+uuid = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
+version = "0.1.0"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[IntervalSets]]
+deps = ["Dates", "EllipsisNotation", "Statistics"]
+git-tree-sha1 = "3cc368af3f110a767ac786560045dceddfc16758"
+uuid = "8197267c-284f-5f27-9208-e0e47529a953"
+version = "0.5.3"
+
+[[InvertedIndices]]
+deps = ["Test"]
+git-tree-sha1 = "15732c475062348b0165684ffe28e85ea8396afc"
+uuid = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
+version = "1.0.0"
+
+[[IterTools]]
+git-tree-sha1 = "05110a2ab1fc5f932622ffea2a003221f4782c18"
+uuid = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
+version = "1.3.0"
+
+[[IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
+
+[[JLLWrappers]]
+deps = ["Preferences"]
+git-tree-sha1 = "642a199af8b68253517b80bd3bfd17eb4e84df6e"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.3.0"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
@@ -40,48 +172,158 @@ uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.1"
 
 [[KeyedDistributions]]
+deps = ["AutoHashEquals", "AxisKeys", "Distributions", "IterTools", "LinearAlgebra", "Random"]
 path = ".."
 uuid = "2576fb08-064d-4cab-b15d-8dda7fcb9a6d"
-version = "0.1.0"
+version = "0.1.2"
+
+[[LazyStack]]
+deps = ["LinearAlgebra", "NamedDims", "OffsetArrays", "Test", "ZygoteRules"]
+git-tree-sha1 = "a8bf67afad3f1ee59d367267adb7c44ccac7fdee"
+uuid = "1fad7336-0346-5a1a-a56f-a06ba010965b"
+version = "0.0.7"
+
+[[LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+
+[[LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
 
 [[LibGit2]]
-deps = ["Printf"]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[LogExpFunctions]]
+deps = ["DocStringExtensions", "LinearAlgebra"]
+git-tree-sha1 = "1ba664552f1ef15325e68dc4c05c3ef8c2d5d885"
+uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+version = "0.2.4"
+
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[MacroTools]]
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "6a8a2a625ab0dea913aba95c11370589e0239ff0"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.6"
 
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
+[[MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+
+[[Missings]]
+deps = ["DataAPI"]
+git-tree-sha1 = "4ea90bd5d3985ae1f9a908bd4500ae88921c5ce7"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "1.0.0"
+
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
+[[MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+
+[[NamedDims]]
+deps = ["AbstractFFTs", "LinearAlgebra", "Pkg", "Requires", "Statistics"]
+git-tree-sha1 = "e91d3ee8ac1514651b6e85686ca31257d17b1eb2"
+uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
+version = "0.2.33"
+
+[[NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[OffsetArrays]]
+deps = ["Adapt"]
+git-tree-sha1 = "e436bb81d2ce4f01fb02374c4410e5a9229c85f9"
+uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+version = "1.10.0"
+
+[[OpenSpecFun_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "13652491f6856acfd2db29360e1bbcd4565d04f1"
+uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
+version = "0.5.5+0"
+
+[[OrderedCollections]]
+git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.4.1"
+
+[[PDMats]]
+deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
+git-tree-sha1 = "4dd403333bcf0909341cfe57ec115152f937d7d8"
+uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
+version = "0.11.1"
+
 [[Parsers]]
 deps = ["Dates"]
-git-tree-sha1 = "223a825cccef2228f3fdbf2ecc7ca93363059073"
+git-tree-sha1 = "c8abc88faa3f7a3950832ac5d6e690881590d6dc"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.16"
+version = "1.1.0"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "00cfd92944ca9c760982747e9a1d0d5d86ab1e5a"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.2.2"
 
 [[Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
+[[QuadGK]]
+deps = ["DataStructures", "LinearAlgebra"]
+git-tree-sha1 = "12fbe86da16df6679be7521dfb39fbc861e1dc7b"
+uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+version = "2.4.1"
+
 [[REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets"]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
 deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "4036a3bd08ac7e968e27c203d45f5fff15020621"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.1.3"
+
+[[Rmath]]
+deps = ["Random", "Rmath_jll"]
+git-tree-sha1 = "bf3188feca147ce108c76ad82c2792c57abe7b1f"
+uuid = "79098fc4-a85e-5d69-aa6a-4863f24498fa"
+version = "0.7.0"
+
+[[Rmath_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "68db32dff12bb6127bac73c209881191bf0efbb7"
+uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
+version = "0.3.0+0"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -89,11 +331,82 @@ uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
+[[SortingAlgorithms]]
+deps = ["DataStructures"]
+git-tree-sha1 = "2ec1962eba973f383239da22e75218565c390a96"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "1.0.0"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[SpecialFunctions]]
+deps = ["ChainRulesCore", "LogExpFunctions", "OpenSpecFun_jll"]
+git-tree-sha1 = "a50550fa3164a8c46747e62063b4d774ac1bcf49"
+uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
+version = "1.5.1"
+
+[[Static]]
+deps = ["IfElse"]
+git-tree-sha1 = "2740ea27b66a41f9d213561a04573da5d3823d4b"
+uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
+version = "0.2.5"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[StatsAPI]]
+git-tree-sha1 = "1958272568dc176a1d881acb797beb909c785510"
+uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
+version = "1.0.0"
+
+[[StatsBase]]
+deps = ["DataAPI", "DataStructures", "LinearAlgebra", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
+git-tree-sha1 = "2f6792d523d7448bbe2fec99eca9218f06cc746d"
+uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+version = "0.33.8"
+
+[[StatsFuns]]
+deps = ["LogExpFunctions", "Rmath", "SpecialFunctions"]
+git-tree-sha1 = "30cd8c360c54081f806b1ee14d2eecbef3c04c49"
+uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
+version = "0.9.8"
+
+[[SuiteSparse]]
+deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
+uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
+
+[[TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[[TableTraits]]
+deps = ["IteratorInterfaceExtensions"]
+git-tree-sha1 = "c06b2f539df1c6efa794486abfb6ed2022561a39"
+uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+version = "1.0.1"
+
+[[Tables]]
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "TableTraits", "Test"]
+git-tree-sha1 = "aa30f8bb63f9ff3f8303a06c604c8500a69aa791"
+uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+version = "1.4.3"
+
+[[Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+
 [[Test]]
-deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[UUIDs]]
@@ -102,3 +415,21 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[ZygoteRules]]
+deps = ["MacroTools"]
+git-tree-sha1 = "9e7a1e8ca60b742e508a315c17eef5211e7fbfd7"
+uuid = "700de1a5-db45-46bc-99cf-38207098b444"
+version = "0.2.1"
+
+[[nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -87,14 +87,14 @@ const KeyedGenericMvTDist = KeyedDistribution{Multivariate, Continuous, <:Generi
 const MvTLike = Union{GenericMvTDist, KeyedGenericMvTDist}
 
 # Use submat to preserve the covariance matrix PDMat type
-function (d::KeyedMvNormal)(keys...)::KeyedMvNormal
-    inds = map(x -> AxisKeys.findindex(x, axiskeys(d)[1]), vcat(keys[1]))
-    return KeyedDistribution(MvNormal(d.d.μ[inds], submat(d.d.Σ, inds)), vcat(keys...))
+function (d::KeyedMvNormal)(keys)::KeyedMvNormal
+    inds = map(x -> AxisKeys.findindex(x, axiskeys(d)[1]), vcat(keys))
+    return KeyedDistribution(MvNormal(d.d.μ[inds], submat(d.d.Σ, inds)), vcat(keys))
 end
 
-function (d::KeyedGenericMvTDist)(keys...)::KeyedGenericMvTDist
-    inds = map(x -> AxisKeys.findindex(x, axiskeys(d)[1]), vcat(keys[1]))
-    return KeyedDistribution(MvTDist(d.d.df, d.d.μ[inds], submat(d.d.Σ, inds)), vcat(keys...))
+function (d::KeyedGenericMvTDist)(keys)::KeyedGenericMvTDist
+    inds = map(x -> AxisKeys.findindex(x, axiskeys(d)[1]), vcat(keys))
+    return KeyedDistribution(MvTDist(d.d.df, d.d.μ[inds], submat(d.d.Σ, inds)), vcat(keys))
 end
 
 # Access methods

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -90,34 +90,22 @@ const KeyedGenericMvTDist = KeyedDistribution{Multivariate, Continuous, <:Generi
 const MvTLike = Union{GenericMvTDist, KeyedGenericMvTDist}
 
 # Use submat to preserve the covariance matrix PDMat type
-function (d::KeyedMvNormal)(keys::Vector)::KeyedMvNormal
-    inds = map(x -> AxisKeys.findindex(x, axiskeys(d)[1]), keys)
-    return KeyedDistribution(MvNormal(d.d.μ[inds], submat(d.d.Σ, inds)), keys)
+function Base.getindex(d::KeyedMvNormal, i::Vector)::KeyedMvNormal
+    return KeyedDistribution(MvNormal(d.d.μ[i], submat(d.d.Σ, i)), axiskeys(d)[1][i])
 end
 
-function (d::KeyedMvNormal)(key)
-    ind = AxisKeys.findindex(key, axiskeys(d)[1])
-    return KeyedDistribution(Normal(d.d.μ[ind], d.d.Σ[ind, ind]), [key])
-end
-
-function (d::KeyedGenericMvTDist)(keys::Vector)::KeyedGenericMvTDist
-    inds = map(x -> AxisKeys.findindex(x, axiskeys(d)[1]), keys)
-    return KeyedDistribution(MvTDist(d.d.df, d.d.μ[inds], submat(d.d.Σ, inds)), keys)
-end
-
-function Base.getindex(d::KeyedMvNormal, inds::Vector)::KeyedMvNormal
-    keys = axiskeys(d)[1]
-    return KeyedDistribution(MvNormal(d.d.μ[inds], submat(d.d.Σ, inds)), keys[inds])
-end
-
-function Base.getindex(d::KeyedMvNormal, i::Integer)
+function Base.getindex(d::KeyedMvNormal, i::Integer)::KeyedDistribution
     return KeyedDistribution(Normal(d.d.μ[i], d.d.Σ[i, i]), [axiskeys(d)[1][i]])
 end
 
-function Base.getindex(d::KeyedGenericMvTDist, inds::Vector)::KeyedGenericMvTDist
-    keys = axiskeys(d)[1]
-    return KeyedDistribution(MvTDist(d.d.df, d.d.μ[inds], submat(d.d.Σ, inds)), keys[inds])
+function Base.getindex(d::KeyedGenericMvTDist, i::Vector)::KeyedGenericMvTDist
+    return KeyedDistribution(MvTDist(d.d.df, d.d.μ[i], submat(d.d.Σ, i)), axiskeys(d)[1][i])
 end
+
+# Use getindex functions to perform lookup
+(d::KeyedMvNormal)(keys::Vector) = d[map(x -> AxisKeys.findindex(x, axiskeys(d)[1]), keys)]
+(d::KeyedMvNormal)(key) = d[AxisKeys.findindex(key, axiskeys(d)[1])]
+(d::KeyedGenericMvTDist)(keys) = d[map(x -> AxisKeys.findindex(x, axiskeys(d)[1]), keys)]
 
 # Access methods
 

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -92,6 +92,15 @@ function (d::KeyedMvNormal)(keys...)::KeyedMvNormal
     )
 end
 
+function (d::KeyedGenericMvTDist)(keys...)::KeyedGenericMvTDist
+    inds = map(x -> AxisKeys.findindex(x, axiskeys(d)[1]), vcat(keys[1]))
+    return KeyedDistribution(
+        # vcat and hcat ensure singleton keys return vector/matrix respectively.
+        MvTDist(d.d.df, vcat(d.d.μ[inds]), hcat(d.d.Σ[inds, inds])),
+        vcat(keys...),
+    )
+end
+
 # Access methods
 
 """

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -66,11 +66,12 @@ _size(d::Sampleable{<:Matrixvariate}) = size(d)
 """
     KeyedDistribution(d::Distribution)
 
-Constructs a [`KeyedDistribution`](@ref) using the keys of the mean component.
-If there are no keys, uses `1:n` for the length `n` of each dimension.
+Constructs a [`KeyedDistribution`](@ref) using the keys of the parameter that matches `size(d)`.
+If the parameter has no keys, uses `1:n` for the length `n` of each dimension.
 """
-KeyedDistribution(d::Distribution) = KeyedDistribution(d, _keys(mean(d)))
+KeyedDistribution(d::Distribution) = KeyedDistribution(d, _keys(d))
 
+_keys(d::Distribution) = _keys(first(filter(x -> size(x) == size(d), params(d))))
 _keys(x::KeyedArray) = axiskeys(x)
 _keys(x) = map(Base.OneTo, size(x))
 
@@ -137,6 +138,8 @@ Base.length(d::KeyedDistOrSampleable) = length(distribution(d))
 Distributions.size(d::KeyedDistribution{<:Matrixvariate}) = size(distribution(d))
 
 Distributions.sampler(d::KeyedDistribution) = sampler(distribution(d))
+
+Distributions.params(d::KeyedDistOrSampleable) = params(distribution(d))
 
 Base.eltype(d::KeyedDistribution) = eltype(distribution(d))
 

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -30,11 +30,12 @@ for T in (:Distribution, :Sampleable)
         univariate and multivariate distributions, and 2 for matrix-variate distributions.
         The length of each key vector in must match the length along each dimension.
 
-        !!! Note
-            Some $($KeyedT)) are callable exactly like `KeyedArray`s. This allows you to
-            marginalise out certain slices for convenience but only for the distributions
-            that support it, like `KeyedMvNormal`s. Also note that marginalising by a
-            singleton will still return a multivariate distribution`.
+        !!! Note round-bracket indexing for marginalizing.
+            For distributions that can be marginalized exactly, $($KeyedT)) are "callable"
+            exactly like `KeyedArray`s, i.e. round-brackets are used to retain certain slices
+            and marginalise out others. For example for `D::KeyedMvNormal` over `:a, :b, :c`:
+             - `D(:a)` will marginalise out `:b, :c` and return a `KeyedMvNormal` over `:a`.
+             - `D([:a, :b])` will marginalise out `:c` and return a `KeyedMvNormal` over `:a, :b`.
         """
         @auto_hash_equals struct $KeyedT{F<:VariateForm, S<:ValueSupport, D<:$T{F, S}} <: $T{F, S}
             d::D

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -66,13 +66,10 @@ _size(d::Sampleable{<:Matrixvariate}) = size(d)
 """
     KeyedDistribution(d::Distribution)
 
-Constructs a [`KeyedDistribution`](@ref) using the keys of the first field stored in `d`,
-or if there are no keys, `1:n` for the length `n` of each dimension.
+Constructs a [`KeyedDistribution`](@ref) using the keys of the mean component.
+If there are no keys, uses `1:n` for the length `n` of each dimension.
 """
-function KeyedDistribution(d::Distribution)
-    first_field = getfield(d, 1)
-    return KeyedDistribution(d, _keys(first_field))
-end
+KeyedDistribution(d::Distribution) = KeyedDistribution(d, _keys(mean(d)))
 
 _keys(x::KeyedArray) = axiskeys(x)
 _keys(x) = map(Base.OneTo, size(x))
@@ -94,7 +91,6 @@ function (d::KeyedMvNormal)(keys...)::KeyedMvNormal
         vcat(keys...)
     )
 end
-
 
 # Access methods
 

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -90,26 +90,33 @@ const KeyedGenericMvTDist = KeyedDistribution{Multivariate, Continuous, <:Generi
 const MvTLike = Union{GenericMvTDist, KeyedGenericMvTDist}
 
 # Use submat to preserve the covariance matrix PDMat type
-function (d::KeyedMvNormal)(keys)::KeyedMvNormal
-    inds = map(x -> AxisKeys.findindex(x, axiskeys(d)[1]), vcat(keys))
-    return KeyedDistribution(MvNormal(d.d.μ[inds], submat(d.d.Σ, inds)), vcat(keys))
+function (d::KeyedMvNormal)(keys::Vector)::KeyedMvNormal
+    inds = map(x -> AxisKeys.findindex(x, axiskeys(d)[1]), keys)
+    return KeyedDistribution(MvNormal(d.d.μ[inds], submat(d.d.Σ, inds)), keys)
 end
 
-function (d::KeyedGenericMvTDist)(keys)::KeyedGenericMvTDist
-    inds = map(x -> AxisKeys.findindex(x, axiskeys(d)[1]), vcat(keys))
-    return KeyedDistribution(MvTDist(d.d.df, d.d.μ[inds], submat(d.d.Σ, inds)), vcat(keys))
+function (d::KeyedMvNormal)(key)
+    ind = AxisKeys.findindex(key, axiskeys(d)[1])
+    return KeyedDistribution(Normal(d.d.μ[ind], d.d.Σ[ind, ind]), [key])
 end
 
-function Base.getindex(d::KeyedMvNormal, inds)::KeyedMvNormal
-    i = vcat(inds)
+function (d::KeyedGenericMvTDist)(keys::Vector)::KeyedGenericMvTDist
+    inds = map(x -> AxisKeys.findindex(x, axiskeys(d)[1]), keys)
+    return KeyedDistribution(MvTDist(d.d.df, d.d.μ[inds], submat(d.d.Σ, inds)), keys)
+end
+
+function Base.getindex(d::KeyedMvNormal, inds::Vector)::KeyedMvNormal
     keys = axiskeys(d)[1]
-    return KeyedDistribution(MvNormal(d.d.μ[i], submat(d.d.Σ, i)), keys[i])
+    return KeyedDistribution(MvNormal(d.d.μ[inds], submat(d.d.Σ, inds)), keys[inds])
 end
 
-function Base.getindex(d::KeyedGenericMvTDist, inds)::KeyedGenericMvTDist
-    i = vcat(inds)
+function Base.getindex(d::KeyedMvNormal, i::Integer)
+    return KeyedDistribution(Normal(d.d.μ[i], d.d.Σ[i, i]), [axiskeys(d)[1][i]])
+end
+
+function Base.getindex(d::KeyedGenericMvTDist, inds::Vector)::KeyedGenericMvTDist
     keys = axiskeys(d)[1]
-    return KeyedDistribution(MvTDist(d.d.df, d.d.μ[i], submat(d.d.Σ, i)), keys[i])
+    return KeyedDistribution(MvTDist(d.d.df, d.d.μ[inds], submat(d.d.Σ, inds)), keys[inds])
 end
 
 # Access methods

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -62,6 +62,9 @@ for T in (:Distribution, :Sampleable)
         The elements of `keys` correspond to the variates of the distribution.
         """
         $KeyedT(d::$T{F, S}, keys::AbstractVector) where {F, S} = $KeyedT(d, (keys, ))
+
+        # Allows marginalisation via lookup syntax, using getindex.
+        (d::$KeyedT)(keys...) = d[first(map(AxisKeys.findindex, keys, axiskeys(d)))]
     end
 end
 
@@ -101,11 +104,6 @@ end
 function Base.getindex(d::KeyedGenericMvTDist, i::Vector)::KeyedGenericMvTDist
     return KeyedDistribution(MvTDist(d.d.df, d.d.μ[i], submat(d.d.Σ, i)), axiskeys(d)[1][i])
 end
-
-# Use getindex functions to perform lookup
-(d::KeyedMvNormal)(keys::Vector) = d[map(x -> AxisKeys.findindex(x, axiskeys(d)[1]), keys)]
-(d::KeyedMvNormal)(key) = d[AxisKeys.findindex(key, axiskeys(d)[1])]
-(d::KeyedGenericMvTDist)(keys) = d[map(x -> AxisKeys.findindex(x, axiskeys(d)[1]), keys)]
 
 # Access methods
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -249,4 +249,29 @@ using Test
         # AxisKeys requires key vectors to be AbstractVector
         @test_throws MethodError T(MvNormal(ones(3)), (:a, :b, :c))
     end
+
+    @testset "marginalising" begin
+
+        X = rand(StableRNG(1234), 10, 3)
+        m = vec(mean(X; dims=1))
+        s = cov(X; dims=1)
+        keys = ([:a, :b, :c], )
+
+        @testset "constructed with keys" begin
+            d = KeyedDistribution(MvNormal(m, s), keys)
+            d([:a, :b, :c]) == d
+            d([:a, :c]) == KeyedDistribution(MvNormal(m[[1, 3]], s[[1, 3], [1, 3]]), [:a, :c])
+            d([:a]) == KeyedDistribution(MvNormal(m[[1]], s[[1], [1]]), [:a])
+            d(:a) == KeyedDistribution(MvNormal(m[[1]], s[[1], [1]]), [:a])
+        end
+
+        @testset "constructed without keys" begin
+            d = KeyedDistribution(MvNormal(m, s))
+            d([1, 2, 3]) == d
+            d([1, 3]) == KeyedDistribution(MvNormal(m[[1, 3]], s[[1, 3], [1, 3]]), [1, 3])
+            d([1]) == KeyedDistribution(MvNormal(m[[1]], s[[1], [1]]), [1])
+            d(1) == KeyedDistribution(MvNormal(m[[1]], s[[1], [1]]), [1])
+        end
+
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -257,7 +257,7 @@ using Test
         s = cov(X; dims=1)
         keys = ([:a, :b, :c], )
 
-        @testset "constructed with keys" begin
+        @testset "KeyedMvNormal constructed with keys" begin
             d = KeyedDistribution(MvNormal(m, s), keys)
             d([:a, :b, :c]) == d
             d([:a, :c]) == KeyedDistribution(MvNormal(m[[1, 3]], s[[1, 3], [1, 3]]), [:a, :c])
@@ -265,12 +265,28 @@ using Test
             d(:a) == KeyedDistribution(MvNormal(m[[1]], s[[1], [1]]), [:a])
         end
 
-        @testset "constructed without keys" begin
+        @testset "KeyedMvNormal constructed without keys" begin
             d = KeyedDistribution(MvNormal(m, s))
             d([1, 2, 3]) == d
             d([1, 3]) == KeyedDistribution(MvNormal(m[[1, 3]], s[[1, 3], [1, 3]]), [1, 3])
             d([1]) == KeyedDistribution(MvNormal(m[[1]], s[[1], [1]]), [1])
             d(1) == KeyedDistribution(MvNormal(m[[1]], s[[1], [1]]), [1])
+        end
+
+        @testset "KeyedMvTDist constructed with keys" begin
+            d = KeyedDistribution(MvTDist(3, m, s), keys)
+            d([:a, :b, :c]) == d
+            d([:a, :c]) == KeyedDistribution(MvTDist(3, m[[1, 3]], s[[1, 3], [1, 3]]), [:a, :c])
+            d([:a]) == KeyedDistribution(MvTDist(3, m[[1]], s[[1], [1]]), [:a])
+            d(:a) == KeyedDistribution(MvTDist(3, m[[1]], s[[1], [1]]), [:a])
+        end
+
+        @testset "KeyedMvTDist constructed without keys" begin
+            d = KeyedDistribution(MvTDist(3, m, s))
+            d([1, 2, 3]) == d
+            d([1, 3]) == KeyedDistribution(MvTDist(3, m[[1, 3]], s[[1, 3], [1, 3]]), [1, 3])
+            d([1]) == KeyedDistribution(MvTDist(3, m[[1]], s[[1], [1]]), [1])
+            d(1) == KeyedDistribution(MvTDist(3, m[[1]], s[[1], [1]]), [1])
         end
 
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,7 @@ using Test
                 @test axiskeys(kd) == keys
                 @test length(kd) == length(d) == 3
                 @test isequal(kd, T(d, [:a, :b, :c]))
+                @test params(kd) == params(d) == (m, s)
                 @test ==(kd, T(d, keys))
             end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -260,46 +260,46 @@ using Test
 
         @testset "KeyedMvNormal constructed with keys" begin
             d = KeyedDistribution(MvNormal(m, s), keys)
-            d([:a, :b, :c]) == d[[1, 2, 3]] == d
+            @test d([:a, :b, :c]) == d[[1, 2, 3]] == d
 
             d13 = KeyedDistribution(MvNormal(m[[1, 3]], s[[1, 3], [1, 3]]), [:a, :c])
-            d([:a, :c]) == d[[1, 3]] == d13
+            @test d([:a, :c]) == d[[1, 3]] == d13
 
             d1 = KeyedDistribution(MvNormal(m[[1]], s[[1], [1]]), [:a])
-            d([:a]) == d[[1]] == d(:a) == d[1] == d1
+            @test d([:a]) == d[[1]] == d(:a) == d[1] == d1
         end
 
         @testset "KeyedMvNormal constructed without keys" begin
             d = KeyedDistribution(MvNormal(m, s))
-            d([1, 2, 3]) == d[[1, 2, 3]] == d
+            @test d([1, 2, 3]) == d[[1, 2, 3]] == d
 
             d13 = KeyedDistribution(MvNormal(m[[1, 3]], s[[1, 3], [1, 3]]), [1, 3])
-            d([1, 3]) == d[[1, 3]] == d13
+            @test d([1, 3]) == d[[1, 3]] == d13
 
             d1 = KeyedDistribution(MvNormal(m[[1]], s[[1], [1]]), [1])
-            d([1]) == d[[1]] == d(1) == d[1] == d1
+            @test d([1]) == d[[1]] == d(1) == d[1] == d1
         end
 
         @testset "KeyedMvTDist constructed with keys" begin
             d = KeyedDistribution(MvTDist(3, m, s), keys)
-            d([:a, :b, :c]) == d[[1, 2, 3]] == d
+            @test d([:a, :b, :c]) == d[[1, 2, 3]] == d
 
             d13 = KeyedDistribution(MvTDist(3, m[[1, 3]], s[[1, 3], [1, 3]]), [:a, :c])
-            d([:a, :c]) == d[[1, 3]] == d13
+            @test d([:a, :c]) == d[[1, 3]] == d13
 
             d1 = KeyedDistribution(MvTDist(3, m[[1]], s[[1], [1]]), [:a])
-            d([:a]) == d[[1]] == d(:a) == d[1] == d1
+            @test d([:a]) == d[[1]] == d(:a) == d[1] == d1
         end
 
         @testset "KeyedMvTDist constructed without keys" begin
             d = KeyedDistribution(MvTDist(3, m, s))
-            d([1, 2, 3]) == d[[1, 2, 3]] == d
+            @test d([1, 2, 3]) == d[[1, 2, 3]] == d
 
             d13 = KeyedDistribution(MvTDist(3, m[[1, 3]], s[[1, 3], [1, 3]]), [1, 3])
-            d([1, 3]) == d[[1, 3]] == d13
+            @test d([1, 3]) == d[[1, 3]] == d13
 
             d1 = KeyedDistribution(MvTDist(3, m[[1]], s[[1], [1]]), [1])
-            d([1]) == d[[1]] == d(1) == d[1] == d1
+            @test d([1]) == d[[1]] == d(1) == d[1] == d1
         end
 
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -265,8 +265,8 @@ using Test
             d13 = KeyedDistribution(MvNormal(m[[1, 3]], s[[1, 3], [1, 3]]), [:a, :c])
             @test d([:a, :c]) == d[[1, 3]] == d13
 
-            d1 = KeyedDistribution(MvNormal(m[[1]], s[[1], [1]]), [:a])
-            @test d([:a]) == d[[1]] == d(:a) == d[1] == d1
+            @test d([:a]) == d[[1]] == KeyedDistribution(MvNormal(m[[1]], s[[1], [1]]), [:a])
+            @test d(:a) == d[1] == KeyedDistribution(Normal(m[1], s[1, 1]), [:a])
         end
 
         @testset "KeyedMvNormal constructed without keys" begin
@@ -276,8 +276,8 @@ using Test
             d13 = KeyedDistribution(MvNormal(m[[1, 3]], s[[1, 3], [1, 3]]), [1, 3])
             @test d([1, 3]) == d[[1, 3]] == d13
 
-            d1 = KeyedDistribution(MvNormal(m[[1]], s[[1], [1]]), [1])
-            @test d([1]) == d[[1]] == d(1) == d[1] == d1
+            @test d([1]) == d[[1]] == KeyedDistribution(MvNormal(m[[1]], s[[1], [1]]), [1])
+            @test d(1) == d[1] == KeyedDistribution(Normal(m[1], s[1, 1]), [1])
         end
 
         @testset "KeyedMvTDist constructed with keys" begin
@@ -287,8 +287,7 @@ using Test
             d13 = KeyedDistribution(MvTDist(3, m[[1, 3]], s[[1, 3], [1, 3]]), [:a, :c])
             @test d([:a, :c]) == d[[1, 3]] == d13
 
-            d1 = KeyedDistribution(MvTDist(3, m[[1]], s[[1], [1]]), [:a])
-            @test d([:a]) == d[[1]] == d(:a) == d[1] == d1
+            @test d([:a]) == d[[1]] == KeyedDistribution(MvTDist(3, m[[1]], s[[1], [1]]), [:a])
         end
 
         @testset "KeyedMvTDist constructed without keys" begin
@@ -298,8 +297,7 @@ using Test
             d13 = KeyedDistribution(MvTDist(3, m[[1, 3]], s[[1, 3], [1, 3]]), [1, 3])
             @test d([1, 3]) == d[[1, 3]] == d13
 
-            d1 = KeyedDistribution(MvTDist(3, m[[1]], s[[1], [1]]), [1])
-            @test d([1]) == d[[1]] == d(1) == d[1] == d1
+            @test d([1]) == d[[1]] == KeyedDistribution(MvTDist(3, m[[1]], s[[1], [1]]), [1])
         end
 
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -260,34 +260,46 @@ using Test
 
         @testset "KeyedMvNormal constructed with keys" begin
             d = KeyedDistribution(MvNormal(m, s), keys)
-            d([:a, :b, :c]) == d
-            d([:a, :c]) == KeyedDistribution(MvNormal(m[[1, 3]], s[[1, 3], [1, 3]]), [:a, :c])
-            d([:a]) == KeyedDistribution(MvNormal(m[[1]], s[[1], [1]]), [:a])
-            d(:a) == KeyedDistribution(MvNormal(m[[1]], s[[1], [1]]), [:a])
+            d([:a, :b, :c]) == d[[1, 2, 3]] == d
+
+            d13 = KeyedDistribution(MvNormal(m[[1, 3]], s[[1, 3], [1, 3]]), [:a, :c])
+            d([:a, :c]) == d[[1, 3]] == d13
+
+            d1 = KeyedDistribution(MvNormal(m[[1]], s[[1], [1]]), [:a])
+            d([:a]) == d[[1]] == d(:a) == d[1] == d1
         end
 
         @testset "KeyedMvNormal constructed without keys" begin
             d = KeyedDistribution(MvNormal(m, s))
-            d([1, 2, 3]) == d
-            d([1, 3]) == KeyedDistribution(MvNormal(m[[1, 3]], s[[1, 3], [1, 3]]), [1, 3])
-            d([1]) == KeyedDistribution(MvNormal(m[[1]], s[[1], [1]]), [1])
-            d(1) == KeyedDistribution(MvNormal(m[[1]], s[[1], [1]]), [1])
+            d([1, 2, 3]) == d[[1, 2, 3]] == d
+
+            d13 = KeyedDistribution(MvNormal(m[[1, 3]], s[[1, 3], [1, 3]]), [1, 3])
+            d([1, 3]) == d[[1, 3]] == d13
+
+            d1 = KeyedDistribution(MvNormal(m[[1]], s[[1], [1]]), [1])
+            d([1]) == d[[1]] == d(1) == d[1] == d1
         end
 
         @testset "KeyedMvTDist constructed with keys" begin
             d = KeyedDistribution(MvTDist(3, m, s), keys)
-            d([:a, :b, :c]) == d
-            d([:a, :c]) == KeyedDistribution(MvTDist(3, m[[1, 3]], s[[1, 3], [1, 3]]), [:a, :c])
-            d([:a]) == KeyedDistribution(MvTDist(3, m[[1]], s[[1], [1]]), [:a])
-            d(:a) == KeyedDistribution(MvTDist(3, m[[1]], s[[1], [1]]), [:a])
+            d([:a, :b, :c]) == d[[1, 2, 3]] == d
+
+            d13 = KeyedDistribution(MvTDist(3, m[[1, 3]], s[[1, 3], [1, 3]]), [:a, :c])
+            d([:a, :c]) == d[[1, 3]] == d13
+
+            d1 = KeyedDistribution(MvTDist(3, m[[1]], s[[1], [1]]), [:a])
+            d([:a]) == d[[1]] == d(:a) == d[1] == d1
         end
 
         @testset "KeyedMvTDist constructed without keys" begin
             d = KeyedDistribution(MvTDist(3, m, s))
-            d([1, 2, 3]) == d
-            d([1, 3]) == KeyedDistribution(MvTDist(3, m[[1, 3]], s[[1, 3], [1, 3]]), [1, 3])
-            d([1]) == KeyedDistribution(MvTDist(3, m[[1]], s[[1], [1]]), [1])
-            d(1) == KeyedDistribution(MvTDist(3, m[[1]], s[[1], [1]]), [1])
+            d([1, 2, 3]) == d[[1, 2, 3]] == d
+
+            d13 = KeyedDistribution(MvTDist(3, m[[1, 3]], s[[1, 3], [1, 3]]), [1, 3])
+            d([1, 3]) == d[[1, 3]] == d13
+
+            d1 = KeyedDistribution(MvTDist(3, m[[1]], s[[1], [1]]), [1])
+            d([1]) == d[[1]] == d(1) == d[1] == d1
         end
 
     end


### PR DESCRIPTION
Extends the AxisKeys lookup syntax to allow extracting sub-components of `MvNormal` and `MvTDist` distributions

```julia
julia> KD = KeyedDistribution(MvNormal(ones(3)), [:a, :b, :c]);

julia> KD([:a, :c])
KeyedMvNormal{ZeroMeanDiagNormal{Tuple{Base.OneTo{Int64}}}}(
d: ZeroMeanDiagNormal(
dim: 2
μ: 2-element Zeros{Float64}
Σ: [1.0 0.0; 0.0 1.0]
)

keys: ([:a, :c],)
)
```