### PR TITLE
Extend Axiskeys haskeys and keyless function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KeyedDistributions"
 uuid = "2576fb08-064d-4cab-b15d-8dda7fcb9a6d"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -123,6 +123,12 @@ Return the keys for the variates of the `KeyedDistribution` or `KeyedSampleable`
 """
 AxisKeys.axiskeys(d::KeyedDistOrSampleable) = d.keys
 
+# Extend AxisKeys function for determining if a type has axis keys and can be generically
+# unwrapped using keyless or keyless_unname.
+AxisKeys.haskeys(d::KeyedDistOrSampleable) = true
+AxisKeys.keyless(d::KeyedDistOrSampleable) = distribution(d)
+AxisKeys.keyless_unname(d::KeyedDistOrSampleable) = distribution(d)
+
 # Standard functions to overload for new Distribution and/or Sampleable
 # https://juliastats.org/Distributions.jl/latest/extends/#Create-New-Samplers-and-Distributions
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -129,6 +129,9 @@ using Test
                     @test kd isa Distribution
                     @test distribution(kd) == d
                     @test axiskeys(kd) == keys
+                    @test AxisKeys.haskeys(kd)
+                    @test AxisKeys.keyless(kd) == d
+                    @test AxisKeys.keyless_unname(kd) == d
                     @test sampler(kd) == sampler(d)
                     @test eltype(kd) == eltype(d) == Float64
                 end


### PR DESCRIPTION
This should make it easier to write generic algorithms that need to unwrap arbitrary Keyed objects.

Closes #34 