### PR TITLE
Add support for mixtures

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KeyedDistributions"
 uuid = "2576fb08-064d-4cab-b15d-8dda7fcb9a6d"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.10"
+version = "0.1.11"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KeyedDistributions"
 uuid = "2576fb08-064d-4cab-b15d-8dda7fcb9a6d"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.12"
+version = "0.1.9"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KeyedDistributions"
 uuid = "2576fb08-064d-4cab-b15d-8dda7fcb9a6d"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.11"
+version = "0.1.12"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KeyedDistributions"
 uuid = "2576fb08-064d-4cab-b15d-8dda7fcb9a6d"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.9"
+version = "0.1.10"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KeyedDistributions"
 uuid = "2576fb08-064d-4cab-b15d-8dda7fcb9a6d"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
 AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150"
 PDMatsExtras = "2c7acb1b-7338-470f-b38f-951d2bcb9193"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -246,7 +246,8 @@ KeyedMixtureModel(cs::Vector{<:KeyedDistribution}, pri::Union{AbstractVector{<:R
 
 KeyedMixtureModel(mm::MixtureModel, keys::Tuple{Vararg{AbstractVector}}) = KeyedDistribution(mm, keys)
 
-KeyedDistribution(kd::KeyedDistribution, keys) = KeyedDistribution(kd.d, keys)
+# Avoid the double wrap
+KeyedDistribution(kd::KeyedDistribution, keys::Tuple{Vararg{AbstractVector{T} where T, N} where N}) = KeyedDistribution(kd.d, keys)
 
 function (mm::KeyedMixtureModel)(keys...) 
     margcomps = map(mm.d.components) do c

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -271,7 +271,7 @@ KeyedDistribution(kd::KeyedDistribution, keys::Tuple{Vararg{AbstractVector{T} wh
 function (mm::KeyedMixtureModel)(keys...) 
     margcomps = map(mm.d.components) do c
         inds = first(map(AxisKeys.findindex, keys, axiskeys(mm)))
-        _marginalize(c, inds)
+        _marginalize(distribution(c), inds)
     end
     return KeyedDistribution(MixtureModel(margcomps), keys)
 end

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -107,6 +107,15 @@ function Base.getindex(d::KeyedGenericMvTDist, i::Vector)::KeyedGenericMvTDist
     return KeyedDistribution(GenericMvTDist(d.d.df, d.d.μ[i], submat(d.d.Σ, i)), axiskeys(d)[1][i])
 end
 
+function Base.getindex(mm::KeyedMixtureModel, i::Vector)::KeyedGenericMvTDist
+    margcomps = map(mm.d.components) do c
+        T = typeof(c)
+        T.name.wrapper(mean(c)[inds], Symmetric(cov(c)[i, i]))
+    end
+    return KeyedDistribution(MixtureModel(margcomps), keys[i])
+end
+
+
 # Access methods
 
 """

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -227,7 +227,7 @@ function Distributions.insupport(d::KeyedDistribution{<:Univariate}, x::Real)
     return insupport(distribution(d), x)
 end
 
-function Distributions.MixtureModel(cs::Vector{C}, pri::CT) where {C <: KeyedDistribution,CT<:Distributions.Categorical}
+function Distributions.MixtureModel(cs::Vector{C}, pri::CT) where {C<:KeyedDistribution,CT<:Distributions.Categorical}
     VF = Distributions.variate_form(C)
     VS = Distributions.value_support(C)
     k = cs[1].keys
@@ -238,9 +238,13 @@ function Distributions.MixtureModel(cs::Vector{C}, pri::CT) where {C <: KeyedDis
     return KeyedDistribution(MixtureModel(distribution.(cs), pri), k)
 end
 
-function Distributions.MixtureModel(cs::Vector{C}, pri::CT) where {C <: KeyedDistribution,CT<:AbstractVector{<:Real}}
+function Distributions.MixtureModel(cs::Vector{C}, pri::CT) where {C<:KeyedDistribution,CT<:AbstractVector{<:Real}}
     return MixtureModel(cs, Categorical(pri))
 end
+
+KeyedMixtureModel(cs::Vector{<:KeyedDistribution}, pri::Union{AbstractVector{<:Real}, Distributions.Categorical}) = MixtureModel(cs, pri)
+
+KeyedMixtureModel(mm::MixtureModel, keys::Tuple{Vararg{AbstractVector}}) = KeyedDistribution(mm, keys)
 
 function (mm::KeyedMixtureModel)(keys...) 
     margcomps = map(mm.d.components) do c

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -119,7 +119,7 @@ function _marginalize(d::MvTDist, i::Vector)
 end
 
 function Base.getindex(mm::KeyedMixtureModel, i::Vector)::KeyedMixtureModel
-    margcomps = map(components(mm)) do c
+    margcomps = map(Distributions.components(mm)) do c
         _marginalize(c, i)
     end
     return KeyedDistribution(MixtureModel(margcomps), only(axiskey(mm))[i])

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -107,7 +107,7 @@ function Base.getindex(d::KeyedGenericMvTDist, i::Vector)::KeyedGenericMvTDist
     return KeyedDistribution(GenericMvTDist(d.d.df, d.d.μ[i], submat(d.d.Σ, i)), axiskeys(d)[1][i])
 end
 
-function Base.getindex(mm::KeyedMixtureModel, i::Vector)::KeyedGenericMvTDist
+function Base.getindex(mm::KeyedMixtureModel, i::Vector)::KeyedMixtureModel
     margcomps = map(mm.d.components) do c
         T = typeof(c)
         T.name.wrapper(mean(c)[inds], Symmetric(cov(c)[i, i]))

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -93,7 +93,7 @@ const KeyedGenericMvTDist = KeyedDistribution{Multivariate, Continuous, <:Generi
 const MvTLike = Union{GenericMvTDist, KeyedGenericMvTDist}
 
 const KeyedMixtureModel = KeyedDistribution{<:VariateForm, <:ValueSupport, <:AbstractMixtureModel}
-const KeyedMixtureLike = Union{MixtureModel, KeyedMixtureModel}
+const MixtureLike = Union{MixtureModel, KeyedMixtureModel}
 
 # Use submat to preserve the covariance matrix PDMat type
 function Base.getindex(d::KeyedMvNormal, i::Vector)::KeyedMvNormal

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -257,7 +257,9 @@ function Distributions.MixtureModel(cs::Vector{C}, pri::CT) where {C<:KeyedDistr
     return KeyedDistribution(MixtureModel(distribution.(cs), pri), k)
 end
 
-function Distributions.MixtureModel(cs::Vector{C}, pri::CT) where {C<:KeyedDistribution,CT<:AbstractVector{<:Real}}
+function Distributions.MixtureModel(
+    cs::Vector{C}, pri::CT
+) where {C<:KeyedDistribution,CT<:AbstractVector{<:Real}}
     return MixtureModel(cs, Categorical(pri))
 end
 

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -261,15 +261,24 @@ function Distributions.MixtureModel(cs::Vector{C}, pri::CT) where {C<:KeyedDistr
     return MixtureModel(cs, Categorical(pri))
 end
 
-KeyedMixtureModel(cs::Vector{<:KeyedDistribution}, pri::Union{AbstractVector{<:Real}, Distributions.Categorical}) = MixtureModel(cs, pri)
+function KeyedMixtureModel(
+    cs::Vector{<:KeyedDistribution},
+    pri::Union{AbstractVector{<:Real},Distributions.Categorical},
+)
+    return MixtureModel(cs, pri)
+end
 
-KeyedMixtureModel(mm::MixtureModel, keys::Tuple{Vararg{AbstractVector}}) = KeyedDistribution(mm, keys)
+function KeyedMixtureModel(mm::MixtureModel, keys::Tuple{Vararg{AbstractVector}})
+    return KeyedDistribution(mm, keys)
+end
 
 # Avoid the double wrap
 KeyedDistribution(kd::KeyedDistribution, keys::Tuple{Vararg{AbstractVector{T} where T, N} where N}) = KeyedDistribution(kd.d, keys)
 
+Distributions.components(kd::KeyedMixtureModel) = Distributions.components(kd.d)
+
 function (mm::KeyedMixtureModel)(keys...) 
-    margcomps = map(mm.d.components) do c
+    margcomps = map(Distributions.components(mm)) do c
         inds = first(map(AxisKeys.findindex, keys, axiskeys(mm)))
         _marginalize(c, inds)
     end

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -119,7 +119,7 @@ function _marginalize(d::MvTDist, i::Vector)
 end
 
 function Base.getindex(mm::KeyedMixtureModel, i::Vector)::KeyedMixtureModel
-    margcomps = map(mm.d.components) do c
+    margcomps = map(components(mm)) do c
         _marginalize(c, i)
     end
     return KeyedDistribution(MixtureModel(margcomps), only(axiskey(mm))[i])

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -110,9 +110,9 @@ end
 function Base.getindex(mm::KeyedMixtureModel, i::Vector)::KeyedMixtureModel
     margcomps = map(mm.d.components) do c
         T = typeof(c)
-        T.name.wrapper(mean(c)[inds], Symmetric(cov(c)[i, i]))
+        T.name.wrapper(mean(c)[i], Symmetric(cov(c)[i, i]))
     end
-    return KeyedDistribution(MixtureModel(margcomps), keys[i])
+    return KeyedDistribution(MixtureModel(margcomps), mm.keys[1][i])
 end
 
 

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -246,6 +246,8 @@ KeyedMixtureModel(cs::Vector{<:KeyedDistribution}, pri::Union{AbstractVector{<:R
 
 KeyedMixtureModel(mm::MixtureModel, keys::Tuple{Vararg{AbstractVector}}) = KeyedDistribution(mm, keys)
 
+KeyedDistribution(kd::KeyedDistribution, keys) = KeyedDistribution(kd.d, keys)
+
 function (mm::KeyedMixtureModel)(keys...) 
     margcomps = map(mm.d.components) do c
         inds = first(map(AxisKeys.findindex, keys, axiskeys(mm)))

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -130,10 +130,6 @@ function _marginalize(d::MvNormal, i::Vector)::MvNormal
     return MvNormal(d.μ[i], submat(d.Σ, i))
 end
 
-function _marginalize(d::MvNormal, i::Integer)::Normal
-    return Normal(Normal(d.d.μ[i], d.d.Σ[i, i]))
-end
-
 function _marginalize(d::MvTDist, i::Vector)::MvTDist
     T = typeof(d)
     return MvTDist(d.df, d.μ[i], submat(d.Σ, i))
@@ -143,7 +139,7 @@ function Base.getindex(mm::KeyedMixtureModel, i::Vector)::KeyedMixtureModel
     margcomps = map(Distributions.components(mm)) do c
         _marginalize(c, i)
     end
-    return KeyedDistribution(MixtureModel(margcomps), only(axiskey(mm))[i])
+    return KeyedDistribution(MixtureModel(margcomps), only(axiskeys(mm))[i])
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -339,6 +339,26 @@ using Test
             @test cov(mm) == cov(d)
             @test cov(mm([:a, :b, :c])) ≈ cov(d)
             @test cov(mm([:a, :c])) ≈ cov(d[[1, 3]])
+            @test cov(mm([:a])) ≈ cov(d[[1]])
+        end
+
+        @testset "Mixture of KeyedMvTDist{AbstractArray, PDMats}" begin
+            keys = [:a, :b, :c]
+            d = KeyedDistribution(MvTDist(2.5, m, Matrix(Symmetric(W))), keys)
+            pri = [0.5, 0.5]
+            mm = KeyedDistribution(MixtureModel([d.d, d.d], pri), keys)
+            mmk = MixtureModel([d, d], pri)
+            kmm1 = KeyedMixtureModel([d, d], pri)
+            kmm2 = KeyedMixtureModel(mm.d, axiskeys(d))
+            @test mm == mmk
+            @test kmm1 == kmm2
+            @test Distributions.logpdf(mm, zeros(3)) ≈ Distributions.logpdf(d, zeros(3))
+            @test cov(mm) == cov(d)
+            @test cov(mm([:a, :b, :c])) ≈ cov(d)
+            @test cov(mm([:a, :c])) ≈ cov(d[[1, 3]])
+            @test cov(mm([:c])) ≈ cov(d[[3]])
         end
     end
 end
+cov(mm([:a, :b, :c]))
+mm([:a, :b, :c])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -322,5 +322,12 @@ using Test
 
             @test d([1]) == d[[1]] == KeyedDistribution(GenericMvTDist(3, m[[1]], submat(W, [1])), [1])
         end
+
+        @testset "Mixture of KeyedMvNormal{AbstractArra, PDMats}" begin
+            k = ["a", "b", "c"]
+            d = KeyedDistribution(MvNormal(m, W), k)
+            kmd = KeyedDistribution(MixtureModel([d, d], [0.5, 0.5]), k)
+            @test Distributions.logpdf(kmd, zeros(3)) == Distributions.logpdf(d, zeros(3))
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -331,7 +331,10 @@ using Test
             pri = [0.5, 0.5]
             mm = KeyedDistribution(MixtureModel([d.d, d.d], pri), keys)
             mmk = MixtureModel([d, d], pri)
+            kmm1 = KeyedMixtureModel([d, d], pri)
+            kmm2 = KeyedMixtureModel(mm.d, axiskeys(d))
             @test mm == mmk
+            @test kmm1 == kmm2
             @test Distributions.logpdf(mm, zeros(3)) == Distributions.logpdf(d, zeros(3))
             @test cov(mm) == cov(d)
             @test cov(mm([:a, :b, :c])) ≈ cov(d)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -380,13 +380,20 @@ using Test
             mmk = MixtureModel([d, d], pri)
             kmm1 = KeyedMixtureModel([d, d], pri)
             kmm2 = KeyedMixtureModel(mm.d, axiskeys(d))
+            kmm3 = KeyedDistribution(mm, axiskeys(mm))
             @test mm == mmk
             @test kmm1 == kmm2
+            @test kmm2 == kmm1
+            @test kmm3 == kmm2
             @test Distributions.logpdf(mm, zeros(3)) == Distributions.logpdf(d, zeros(3))
             @test cov(mm) == cov(d)
             @test cov(mm([:a, :b, :c])) ≈ cov(d)
             @test cov(mm([:a, :c])) ≈ cov(d[[1, 3]])
             @test cov(mm([:a])) ≈ cov(d[[1]])
+            @test only(cov(KeyedDistributions._marginalize(distribution(d), [2]))) ≈ cov(d)[2, 2]
+            @test mean(d[[2]]) == mean(mm[[2]])
+            @test cov(d[[2]]) == cov(mm[[2]])
+            @test mm isa MixtureModelLike
         end
 
         @testset "Mixture of KeyedMvTDist{AbstractArray, PDMats}" begin
@@ -404,6 +411,8 @@ using Test
             @test cov(mm([:a, :b, :c])) ≈ cov(d)
             @test cov(mm([:a, :c])) ≈ cov(d[[1, 3]])
             @test cov(mm([:c])) ≈ cov(d[[3]])
+            @test only(cov(KeyedDistributions._marginalize(distribution(d), [2]))) ≈ cov(d)[2, 2]
+            @test mm isa MixtureModelLike
         end
     end
 


### PR DESCRIPTION
Implements constructors and marginalisation for Distributions.MixtureModel, and a UnionAll type KeyedMixtureModel

https://github.com/invenia/KeyedDistributions.jl/issues/5