### PR TITLE
Add missing Distributions methods for KeyedMixtureModel

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KeyedDistributions"
 uuid = "2576fb08-064d-4cab-b15d-8dda7fcb9a6d"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.16"
+version = "0.1.17"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/src/KeyedDistributions.jl
+++ b/src/KeyedDistributions.jl
@@ -214,6 +214,12 @@ Distributions.sampler(d::KeyedDistribution) = sampler(distribution(d))
 
 Distributions.params(d::KeyedDistOrSampleable) = params(distribution(d))
 
+Distributions.probs(d::KeyedMixtureModel) = probs(distribution(d))
+
+Distributions.components(d::KeyedMixtureModel) = components(distribution(d))
+
+Distributions.ncomponents(d::KeyedMixtureModel) = ncomponents(distribution(d))
+
 Base.eltype(d::KeyedDistribution) = eltype(distribution(d))
 
 function Distributions._logpdf(d::KeyedDistribution, x::AbstractArray)
@@ -340,8 +346,6 @@ function KeyedDistribution(
 )
     return KeyedDistribution(kd.d, keys)
 end
-
-Distributions.components(kd::KeyedMixtureModel) = Distributions.components(kd.d)
 
 function (mm::KeyedMixtureModel)(keys...)
     margcomps = map(Distributions.components(mm)) do c

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -404,6 +404,9 @@ using Test
             @test mean(d[[2]]) == mean(mm[[2]])
             @test cov(d[[2]]) == cov(mm[[2]])
             @test mm isa MixtureModelLike
+            @test probs(mm) == pri
+            @test ncomponents(mm) == 2
+            @test components(mm) == [d, d]
         end
 
         @testset "Mixture of KeyedMvTDist{AbstractArray, PDMats}" begin


### PR DESCRIPTION
`Distributions.ncomponents` and `Distributions.probs` are missing.  This MR adds them.